### PR TITLE
Add coverage reporting to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,5 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Run tests
-      run: pytest -v
+    - name: Run tests with coverage
+      run: pytest -v --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=80


### PR DESCRIPTION
- Configure pytest to run with coverage tracking
- Add term-missing and XML coverage reports
- Set minimum coverage threshold to 80%