### PR TITLE
fix: address PR #26 review comments - improve PyPI workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,5 +1,9 @@
 name: Publish to PyPI
 
+# Required GitHub Secrets:
+# - PYPI_API_TOKEN: API token for publishing to PyPI (https://pypi.org/manage/account/token/)
+# - TEST_PYPI_API_TOKEN: API token for TestPyPI (https://test.pypi.org/manage/account/token/)
+
 on:
   release:
     types: [published]
@@ -35,6 +39,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Install spaCy language models
+        run: |
+          uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+          uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl
+
+      - name: Clone test fixture
+        run: |
+          git clone https://github.com/wende/ab tests/fixtures/elixir_project
+
       - name: Run tests
         run: uv run pytest
 
@@ -51,7 +64,7 @@ jobs:
             --token $UV_PUBLISH_TOKEN
 
       - name: Publish to PyPI
-        if: github.event_name == 'release' && github.event.inputs.test_pypi != 'true'
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_pypi != 'true')
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
@@ -62,4 +75,4 @@ jobs:
         run: |
           sleep 60  # Wait for PyPI to index the package
           pip install cicada
-          cicada --version
+          python -c "import cicada; print(f'Cicada version: {cicada.__version__}')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- GitHub Actions workflow for automated PyPI publishing ([#26](https://github.com/wende/cicada/pull/26))
+- MIT License file for PyPI compliance ([#26](https://github.com/wende/cicada/pull/26))
+- Enhanced pyproject.toml with complete package metadata for PyPI ([#26](https://github.com/wende/cicada/pull/26))
+
 ## [0.1.2] - 2025-01-XX
 
 ### Added


### PR DESCRIPTION
Address all critical and medium-priority issues from Claude Bot review:

Critical fixes:
- Add spaCy model installation (en_core_web_sm and en_core_web_md) to prevent test failures
- Clone test fixture repository before running tests
- Fix package verification command to use Python import instead of non-existent --version flag
- Add CHANGELOG.md entry for PyPI publishing infrastructure

Medium fixes:
- Document required GitHub secrets (PYPI_API_TOKEN and TEST_PYPI_API_TOKEN) in workflow comments
- Fix workflow dispatch logic to properly handle both release and manual triggers

The workflow now mirrors the test.yml setup for proper CI testing before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)