### PR TITLE
fix: add missing test fixture setup step in PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           git clone https://github.com/wende/ab tests/fixtures/elixir_project
 
+      - name: Setup test fixtures
+        run: bash tests/setup_fixtures.sh
+
       - name: Run tests
         run: uv run pytest
 


### PR DESCRIPTION
The publish-pypi workflow was missing a critical step to setup test fixtures before running pytest. This caused tests to fail because the fixture index wasn't generated.

The test.yml workflow correctly uses 'make ci-test' which includes the setup-fixtures step, but publish-pypi.yml was calling pytest directly.

This fix adds the missing 'bash tests/setup_fixtures.sh' step after cloning the test fixture and before running tests.

Fixes test failures in GitHub Actions by ensuring the test fixture index is properly generated before tests run.