### PR TITLE
fix: remove invalid 'Programming Language :: Elixir' PyPI classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Elixir",
     "Topic :: Software Development :: Code Generators",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Version Control :: Git",


### PR DESCRIPTION
PyPI does not recognize Elixir as a valid programming language classifier. This was causing the PyPI publishing workflow to fail.