### PR TITLE
feat: migrate to PyPI installation with uvx support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,20 +12,18 @@ When creating a new release:
    git push origin v0.X.Y
    ```
 
-2. **Update README.md version references:**
-   - Search for all instances of `@v0.1.1` in README.md
-   - Replace with the new version tag `@v0.X.Y`
-   - Locations to update:
-     - Quick Install section (stable release command)
-     - Try Before Installing section (stable release command)
-     - Migration tip section
-
-3. **Update pyproject.toml version:**
+2. **Update pyproject.toml version:**
    - Update the `version = "0.1.1"` field to match the new release
+
+3. **Build and publish to PyPI:**
+   ```bash
+   uv build
+   uv publish
+   ```
 
 4. **Test the installation:**
    ```bash
-   uv tool install git+https://github.com/wende/cicada.git@v0.X.Y
+   uv tool install cicada-mcp
    ```
 
 ## Project Context
@@ -86,7 +84,7 @@ This project uses **uv** as the primary Python package manager and build tool. W
 - **Add new dependencies:** `uv add <package-name>`
 - **Run commands:** `uv run <command>` (e.g., `uv run python -m pytest`)
 - **Install the project:** `uv pip install -e .` for development installation
-- **Tool installation:** `uv tool install git+https://github.com/wende/cicada.git@v0.X.Y`
+- **Tool installation:** `uv tool install cicada-mcp`
 
 The project includes `uv.lock` for reproducible builds and `pyproject.toml` for project configuration.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Elixir](https://img.shields.io/badge/Elixir-Support-purple.svg)](https://elixir-lang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=cicada&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBnaXQraHR0cHM6Ly9naXRodWIuY29tL3dlbmRlL2NpY2FkYS5naXRAbGF0ZXN0IGNpY2FkYS1zZXJ2ZXIgLiJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=cicada&config=eyJjb21tYW5kIjoidXZ4IGNpY2FkYS1tY3AgLiJ9)
 
 [Installation](#installation) •
 [Quick Start](#quick-start) •
@@ -75,7 +75,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ```bash
 # Step 1: Install once
-uv tool install git+https://github.com/wende/cicada.git@latest
+uv tool install cicada-mcp
 
 # Step 2: Setup in each project (one command per project)
 cd /path/to/your/elixir/project
@@ -107,13 +107,13 @@ Want to test Cicada first? Use `uvx` for a quick trial:
 cd /path/to/your/elixir/project
 
 # For Claude Code
-uvx --from git+https://github.com/wende/cicada.git@latest cicada claude
+uvx --from cicada-mcp cicada claude
 
 # For Cursor
-uvx --from git+https://github.com/wende/cicada.git@latest cicada cursor
+uvx --from cicada-mcp cicada cursor
 
 # For VS Code
-uvx --from git+https://github.com/wende/cicada.git@latest cicada vs
+uvx --from cicada-mcp cicada vs
 ```
 
 **Note:** `uvx` is perfect for trying Cicada, but **permanent installation is recommended** because:
@@ -130,26 +130,26 @@ Once you're convinced, install permanently with `uv tool install` above!
 **For Cursor:**
 
 Click the install button at the top of this README or visit:
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=cicada&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBnaXQraHR0cHM6Ly9naXRodWIuY29tL3dlbmRlL2NpY2FkYS5naXRAbGF0ZXN0IGNpY2FkYS1zZXJ2ZXIgLiJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=cicada&config=eyJjb21tYW5kIjoidXZ4IGNpY2FkYS1tY3AgLiJ9)
 
 **For Claude Code:**
 
 ```bash
 # Option 1: Using claude mcp add command
-claude mcp add cicada -- uvx --from git+https://github.com/wende/cicada.git@latest cicada-mcp ./path/to/your/codebase
+claude mcp add cicada -- uvx cicada-mcp ./path/to/your/codebase
 
 # Option 2: Using setup script
-uvx --from git+https://github.com/wende/cicada.git@latest cicada claude
+uvx --from cicada-mcp cicada claude
 ```
 
 **Then for both editors,** run these commands in your codebase to generate keyword lookup and GitHub PR lookup databases:
 
 ```bash
 # Generate keyword lookup database
-uvx --from git+https://github.com/wende/cicada.git@latest cicada-index .
+uvx --from cicada-mcp cicada-index .
 
 # Generate GitHub PR lookup database
-uvx --from git+https://github.com/wende/cicada.git@latest cicada-index-pr .
+uvx --from cicada-mcp cicada-index-pr .
 ```
 
 ---
@@ -220,7 +220,7 @@ After code changes, re-run the setup command:
 
 ```bash
 # Re-index for Claude Code
-uvx --from git+https://github.com/wende/cicada.git@latest cicada claude
+uvx --from cicada-mcp cicada claude
 
 # Or if permanently installed
 cicada claude
@@ -240,7 +240,7 @@ Index pull requests for PR-related features:
 cicada-index-pr .
 
 # Or with uvx
-uvx --from git+https://github.com/wende/cicada.git@latest cicada-index-pr .
+uvx --from cicada-mcp cicada-index-pr .
 ```
 
 ### Legacy Installation

--- a/cicada/setup.py
+++ b/cicada/setup.py
@@ -2,10 +2,11 @@
 """
 Cicada Simplified Setup Script.
 
-One-command setup: uvx cicada [claude|cursor|vs]
+One-command setup: uvx --from cicada-mcp cicada [claude|cursor|vs]
 - Indexes the repository with keyword extraction
 - Stores all files in temp directory (~/.cicada/projects/<hash>/)
 - Creates only MCP config file in user's repo
+- Generates MCP config that uses 'uvx cicada-mcp' (works with or without permanent install)
 """
 
 import argparse
@@ -99,26 +100,11 @@ def get_mcp_config_for_editor(
     Returns:
         Tuple of (config_file_path, config_content)
     """
-    # Detect installation method
-    import shutil
-
-    # Check for cicada-mcp first (new name), fall back to cicada-server (backwards compat)
-    has_cicada_mcp = shutil.which("cicada-mcp") is not None
-    has_cicada_server = shutil.which("cicada-server") is not None
-
-    if has_cicada_mcp:
-        command = "cicada-mcp"
-        args = []
-        cwd = None
-    elif has_cicada_server:
-        command = "cicada-server"
-        args = []
-        cwd = None
-    else:
-        python_bin = sys.executable
-        command = str(python_bin)
-        args = ["-m", "cicada.mcp_server"]
-        cwd = None
+    # Always use uvx for maximum compatibility
+    # Works whether cicada-mcp is permanently installed or not
+    command = "uvx"
+    args = ["cicada-mcp"]
+    cwd = None
 
     # Editor-specific specifications
     editor_specs = {
@@ -286,17 +272,14 @@ def setup(editor: EditorType, repo_path: Path | None = None) -> None:
 
     # Check if running via uvx and suggest permanent installation
     import shutil
-    from cicada import __version__
 
     # Check for either cicada-mcp or cicada-server (backwards compat)
     if not (shutil.which("cicada-mcp") or shutil.which("cicada-server")):
         print("💡 Tip: For best experience, install Cicada permanently:")
-        print(
-            f"   uv tool install git+https://github.com/wende/cicada.git@v{__version__}"
-        )
+        print("   uv tool install cicada-mcp")
         print()
         print("   Benefits:")
-        print("   • Faster MCP server startup")
+        print("   • Faster MCP server startup (no uvx overhead)")
         print("   • Access to cicada-index with medium/large spaCy models")
         print("   • PR indexing with cicada-index-pr")
         print()
@@ -306,7 +289,7 @@ def main():
     """Main entry point for the simplified setup script."""
     parser = argparse.ArgumentParser(
         description="Cicada One-Command Setup",
-        epilog="Example: uvx cicada claude",
+        epilog="Example: uvx --from cicada-mcp cicada claude",
     )
     parser.add_argument(
         "editor",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -79,42 +79,20 @@ class TestGetMcpConfigForEditor:
         assert server_config["env"]["CICADA_REPO_PATH"] == str(mock_repo)
 
     def test_with_cicada_server_installed(self, mock_repo, mock_storage_dir):
-        """Should use cicada-mcp command when available (with cicada-server as fallback)"""
-        # Test with cicada-mcp available
-        with patch(
-            "shutil.which",
-            side_effect=lambda tool: "cicada-mcp" if tool == "cicada-mcp" else None,
-        ):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
+        """Should always use uvx cicada-mcp for maximum compatibility"""
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         server_config = config["mcpServers"]["cicada"]
-        assert server_config["command"] == "cicada-mcp"
-        assert "args" not in server_config or server_config.get("args") == []
-
-        # Test backwards compatibility with only cicada-server available
-        with patch(
-            "shutil.which",
-            side_effect=lambda tool: (
-                "cicada-server" if tool == "cicada-server" else None
-            ),
-        ):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
-
-        server_config = config["mcpServers"]["cicada"]
-        assert server_config["command"] == "cicada-server"
-        assert "args" not in server_config or server_config.get("args") == []
+        assert server_config["command"] == "uvx"
+        assert server_config["args"] == ["cicada-mcp"]
 
     def test_without_cicada_server_installed(self, mock_repo, mock_storage_dir):
-        """Should use python -m command when cicada-server not available"""
-        with patch("shutil.which", return_value=None):
-            with patch("sys.executable", "/usr/bin/python3"):
-                _, config = get_mcp_config_for_editor(
-                    "claude", mock_repo, mock_storage_dir
-                )
+        """Should always use uvx cicada-mcp regardless of installation status"""
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         server_config = config["mcpServers"]["cicada"]
-        assert server_config["command"] == "/usr/bin/python3"
-        assert server_config["args"] == ["-m", "cicada.mcp_server"]
+        assert server_config["command"] == "uvx"
+        assert server_config["args"] == ["cicada-mcp"]
 
     def test_preserves_existing_config(self, mock_repo, mock_storage_dir):
         """Should preserve existing configuration when adding cicada"""
@@ -127,8 +105,7 @@ class TestGetMcpConfigForEditor:
         }
         config_path.write_text(json.dumps(existing_config))
 
-        with patch("shutil.which", return_value="cicada-server"):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         # Should preserve other-server
         assert "other-server" in config["mcpServers"]
@@ -141,8 +118,7 @@ class TestGetMcpConfigForEditor:
         config_path = mock_repo / ".mcp.json"
         config_path.write_text("{invalid json}")
 
-        with patch("shutil.which", return_value="cicada-server"):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         # Should create valid config despite malformed input
         assert "mcpServers" in config
@@ -151,8 +127,7 @@ class TestGetMcpConfigForEditor:
     def test_handles_io_error(self, mock_repo, mock_storage_dir):
         """Should handle IO errors gracefully"""
         # No existing file - should create new config
-        with patch("shutil.which", return_value="cicada-server"):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         assert "mcpServers" in config
         assert "cicada" in config["mcpServers"]
@@ -170,15 +145,12 @@ class TestGetMcpConfigForEditor:
         }
         config_path.write_text(json.dumps(existing_config))
 
-        with patch(
-            "shutil.which",
-            side_effect=lambda tool: "cicada-mcp" if tool == "cicada-mcp" else None,
-        ):
-            _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
+        _, config = get_mcp_config_for_editor("claude", mock_repo, mock_storage_dir)
 
         # Should replace old cicada config
         server_config = config["mcpServers"]["cicada"]
-        assert server_config["command"] == "cicada-mcp"
+        assert server_config["command"] == "uvx"
+        assert server_config["args"] == ["cicada-mcp"]
         assert "CICADA_REPO_PATH" in server_config["env"]
 
 


### PR DESCRIPTION
Update all documentation and setup code to use the cicada-mcp PyPI package instead of git URLs. The setup script now generates MCP configs that use 'uvx cicada-mcp' which works whether the package is permanently installed or run on-demand via uvx.

Changes:
- setup.py: Always generate 'uvx cicada-mcp' in MCP configs for compatibility
- README.md: Replace all git URLs with PyPI package commands
- CLAUDE.md: Update release process to include PyPI build/publish steps
- Cursor deep link: Update to use simplified 'uvx cicada-mcp .' command
- Tests: Update expectations to match new uvx-based config generation

Benefits:
- Simpler installation: 'uv tool install cicada-mcp' vs git URL
- No double downloads: uvx caches packages efficiently
- Works with both permanent install and uvx one-off usage
- Automatic version management through PyPI