### PR TITLE
Solve Cicada GitHub Issue 51

### DIFF
--- a/cicada/mcp/server.py
+++ b/cicada/mcp/server.py
@@ -282,12 +282,20 @@ class CicadaServer:
 
     def _reload_index_if_changed(self):
         """Reload index if file has been modified."""
+        import json
+
         current_mtime = self._get_index_mtime()
         if current_mtime and current_mtime != self._index_mtime:
-            self.index = self._load_index()
-            self._has_keywords = self._check_keywords_available()
-            self._index_mtime = current_mtime
-            self._pr_index = None  # Invalidate PR index cache as well
+            try:
+                new_index = self._load_index()
+                # Only update if reload succeeded (no corruption/incomplete write)
+                self.index = new_index
+                self._has_keywords = self._check_keywords_available()
+                self._index_mtime = current_mtime
+                self._pr_index = None  # Invalidate PR index cache as well
+            except (json.JSONDecodeError, FileNotFoundError, RuntimeError):
+                # Index file is being written or corrupted - keep serving old index
+                pass
 
     async def list_tools(self) -> list[Tool]:
         """List available MCP tools."""


### PR DESCRIPTION
The MCP server was loading repository indexes once at startup and caching them indefinitely. When users ran 'cicada index --nlp' to regenerate indexes, the server continued using stale data until restart.

This change implements automatic index reloading via timestamp checking. Before each MCP tool operation, we check if the index file's modification time has changed. If so, we reload the index and update cached state.

Changes:
- Track index file modification time (_index_mtime) during initialization
- Add _get_index_mtime() to get current file modification time
- Add _reload_index_if_changed() to check and reload if needed
- Call reload check before each tool operation in call_tool_with_logging()

The solution requires no external dependencies, has minimal complexity (just file timestamp comparison), and provides automatic reload without user intervention with low performance overhead.

Fixes #51