### PR TITLE
Add Gemini CLI and Codex to interactive setup menu

### DIFF
--- a/cicada/_version_hash.py
+++ b/cicada/_version_hash.py
@@ -1,4 +1,4 @@
 """Auto-generated file containing build-time git tag and hash."""
 
-GIT_TAG = "v0.2.3"
-GIT_HASH = "eec0ba0"
+GIT_TAG = "v0.3.0-rc0"
+GIT_HASH = "09b27cf"

--- a/cicada/interactive_setup_helpers.py
+++ b/cicada/interactive_setup_helpers.py
@@ -26,9 +26,11 @@ TIER_MAP_TEXT = {str(idx + 1): methods for idx, methods in TIER_MAP.items()}
 
 # Editor configuration data
 _EDITOR_OPTIONS = (
-    ("Claude Code - AI-powered code editor", "claude"),
-    ("Cursor - AI-first code editor", "cursor"),
-    ("VS Code - Visual Studio Code", "vs"),
+    ("Claude Code", "claude"),
+    ("Cursor", "cursor"),
+    ("VS Code", "vs"),
+    ("Gemini CLI", "gemini"),
+    ("Codex", "codex"),
 )
 
 EDITOR_ITEMS = [label for label, _ in _EDITOR_OPTIONS]
@@ -136,7 +138,7 @@ def display_editor_selection(editor: str) -> None:
     Display confirmation message for editor selection.
 
     Args:
-        editor: The selected editor ('claude', 'cursor', or 'vs')
+        editor: The selected editor ('claude', 'cursor', 'vs', 'gemini', or 'codex')
     """
     print()
     print(f"{GREEN}✓{RESET} Selected: {editor.upper()}")

--- a/tests/test_interactive_setup.py
+++ b/tests/test_interactive_setup.py
@@ -845,6 +845,28 @@ class TestTextBasedEditorSelection:
         assert editor == "vs"
 
     @patch("builtins.input")
+    def test_gemini_selection(self, mock_input):
+        """Test selecting Gemini CLI"""
+        from cicada.interactive_setup import _text_based_editor_selection
+
+        mock_input.return_value = "4"
+
+        editor = _text_based_editor_selection()
+
+        assert editor == "gemini"
+
+    @patch("builtins.input")
+    def test_codex_selection(self, mock_input):
+        """Test selecting Codex"""
+        from cicada.interactive_setup import _text_based_editor_selection
+
+        mock_input.return_value = "5"
+
+        editor = _text_based_editor_selection()
+
+        assert editor == "codex"
+
+    @patch("builtins.input")
     def test_default_selection(self, mock_input):
         """Test default selection (empty input defaults to Claude)"""
         from cicada.interactive_setup import _text_based_editor_selection
@@ -905,6 +927,8 @@ class TestTextBasedEditorSelection:
         assert "Claude Code" in captured.out
         assert "Cursor" in captured.out
         assert "VS Code" in captured.out
+        assert "Gemini CLI" in captured.out
+        assert "Codex" in captured.out
 
 
 class TestShowFullInteractiveSetup:


### PR DESCRIPTION
The interactive setup helpers were missing Gemini and Codex from the _EDITOR_OPTIONS tuple, even though the functionality was fully implemented. This caused the setup menu to only show 3 editors (Claude Code, Cursor, VS Code) instead of all 5 supported editors.

Changes:
- Add Gemini CLI and Codex to _EDITOR_OPTIONS
- Remove verbose descriptions from all editor options
- Add tests for Gemini and Codex selection
- Update test to verify all 5 editors are displayed

Fixes #82