### PR TITLE
Add --default flag to index command for quick initialization

### DIFF
--- a/cicada/_version_hash.py
+++ b/cicada/_version_hash.py
@@ -1,4 +1,4 @@
 """Auto-generated file containing build-time git tag and hash."""
 
-GIT_TAG = "v0.3.1rc2"
-GIT_HASH = "9c57cec"
+GIT_TAG = "latest"
+GIT_HASH = "1a5ade5"

--- a/cicada/commands.py
+++ b/cicada/commands.py
@@ -383,6 +383,11 @@ def get_argument_parser():
         help="Override configured tier (requires --fast, --regular, or --max)",
     )
     index_parser.add_argument(
+        "--default",
+        action="store_true",
+        help="Initialize with default values (equivalent to --force --fast)",
+    )
+    index_parser.add_argument(
         "--test",
         action="store_true",
         help="Start interactive keyword extraction test mode",
@@ -683,6 +688,11 @@ def handle_index_main(args) -> None:
     """Handle main repository indexing."""
     from cicada.indexer import ElixirIndexer
     from cicada.utils.storage import create_storage_dir, get_config_path, get_index_path
+
+    # Handle --default flag: convert to --force --fast
+    if getattr(args, "default", False):
+        args.force = True
+        args.fast = True
 
     # Validate tier flags
     validate_tier_flags(args, require_force=True)

--- a/tests/setup/test_cli.py
+++ b/tests/setup/test_cli.py
@@ -30,6 +30,7 @@ def make_index_args(**overrides):
         "max": False,
         "regular": False,
         "force": False,
+        "default": False,
         "repo": ".",
         "test": False,
         "test_expansion": False,


### PR DESCRIPTION
The --default flag is equivalent to --force --fast, enabling users to initialize cicada with default values (fast tier: REGULAR extraction + LEMMI expansion) without any prompts or interactive setup.