### PR TITLE
Fix file watcher threading error with signal handlers

### DIFF
--- a/cicada/indexer.py
+++ b/cicada/indexer.py
@@ -371,8 +371,13 @@ class ElixirIndexer:
                 print(f"Tier: {tier.upper()}")
 
         # Set up signal handlers for graceful interruption
-        signal.signal(signal.SIGINT, self._handle_interrupt)
-        signal.signal(signal.SIGTERM, self._handle_interrupt)
+        # Only works in main thread - skip if called from background thread
+        try:
+            signal.signal(signal.SIGINT, self._handle_interrupt)
+            signal.signal(signal.SIGTERM, self._handle_interrupt)
+        except ValueError:
+            # Running in background thread - signal handlers unavailable
+            pass
         self._interrupted = False
 
         # Initialize keyword extractor and expander if requested
@@ -1023,8 +1028,13 @@ class ElixirIndexer:
             print(f"Tier: {tier.upper()}")
 
         # Set up signal handlers for graceful interruption
-        signal.signal(signal.SIGINT, self._handle_interrupt)
-        signal.signal(signal.SIGTERM, self._handle_interrupt)
+        # Only works in main thread - skip if called from background thread
+        try:
+            signal.signal(signal.SIGINT, self._handle_interrupt)
+            signal.signal(signal.SIGTERM, self._handle_interrupt)
+        except ValueError:
+            # Running in background thread - signal handlers unavailable
+            pass
         self._interrupted = False
 
         # Find all current Elixir files


### PR DESCRIPTION
When the file watcher triggers reindexing from a background thread, signal handler registration fails with 'signal only works in main thread of the main interpreter'. Wrap signal.signal() calls in try-except to gracefully handle background thread execution while preserving signal handling for main thread CLI usage.