### PR TITLE
Fix Gemini CLI config path to use settings.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ As of the simplified setup workflow (PR #20), Cicada uses a centralized storage 
   - `.mcp.json` (Claude Code)
   - `.cursor/mcp.json` (Cursor)
   - `.vscode/settings.json` (VS Code)
-  - `.gemini/mcp.json` (Gemini CLI)
+  - `.gemini/settings.json` (Gemini CLI)
   - `.codex/mcp.json` (Codex)
   - `.opencode.json` (OpenCode)
 
@@ -80,7 +80,7 @@ The MCP server uses environment variables to locate configuration files:
 
 - **CICADA_CONFIG_DIR** (Required by MCP config files)
   - Points directly to the storage directory: `~/.cicada/projects/<hash>/`
-  - Set in `.mcp.json`, `.cursor/mcp.json`, `.vscode/settings.json`, `.gemini/mcp.json`, `.codex/mcp.json`, and `.opencode.json`
+  - Set in `.mcp.json`, `.cursor/mcp.json`, `.vscode/settings.json`, `.gemini/settings.json`, `.codex/mcp.json`, and `.opencode.json`
   - Primary mechanism for config file resolution
   - Example: `/Users/username/.cicada/projects/a1b2c3d4e5f6g7h8/`
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Ask your assistant:
   ├─ hashes.json     # incremental indexing cache
   └─ pr_index.json   # optional PR metadata + reviews
   ```
-  Your repo only gains an editor config (`.mcp.json`, `.cursor/mcp.json`, `.vscode/settings.json`, `.gemini/mcp.json`, `.codex/mcp.json`, or `.opencode.json`).
+  Your repo only gains an editor config (`.mcp.json`, `.cursor/mcp.json`, `.vscode/settings.json`, `.gemini/settings.json`, `.codex/mcp.json`, or `.opencode.json`).
 
 ---
 

--- a/cicada/editor_specs.py
+++ b/cicada/editor_specs.py
@@ -57,7 +57,7 @@ EDITOR_SPECS: tuple[EditorSpec, ...] = (
         cli_help="Setup Cicada for Gemini CLI",
         cli_description="One-command setup for Gemini CLI with keyword extraction",
         prompt_label="Gemini CLI (Google Gemini command line interface)",
-        config_relpath=Path(".gemini") / "mcp.json",
+        config_relpath=Path(".gemini") / "settings.json",
         config_key="mcpServers",
         needs_dir=True,
     ),

--- a/cicada/setup.py
+++ b/cicada/setup.py
@@ -169,7 +169,7 @@ def get_mcp_config_for_editor(
             "needs_dir": True,
         },
         "gemini": {
-            "config_path": repo_path / ".gemini" / "mcp.json",
+            "config_path": repo_path / ".gemini" / "settings.json",
             "config_key": "mcpServers",
             "needs_dir": True,
         },

--- a/cicada/status.py
+++ b/cicada/status.py
@@ -176,7 +176,7 @@ def find_mcp_files(repo_path: Path) -> dict:
             "editor": "VS Code",
         },
         {
-            "path": repo_path / ".gemini" / "mcp.json",
+            "path": repo_path / ".gemini" / "settings.json",
             "description": "Gemini CLI config",
             "editor": "Gemini CLI",
         },

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -75,7 +75,7 @@ class TestGetMcpConfigForEditor:
         with patch("shutil.which", return_value="cicada-server"):
             config_path, config = get_mcp_config_for_editor("gemini", mock_repo, mock_storage_dir)
 
-        assert config_path == mock_repo / ".gemini" / "mcp.json"
+        assert config_path == mock_repo / ".gemini" / "settings.json"
         assert "mcpServers" in config
         assert "cicada" in config["mcpServers"]
 

--- a/tests/test_editor_specs.py
+++ b/tests/test_editor_specs.py
@@ -122,7 +122,7 @@ class TestEditorSpecs:
         """Should have correct Gemini spec"""
         gemini_spec = next(s for s in EDITOR_SPECS if s.name == "gemini")
         assert gemini_spec.cli_help == "Setup Cicada for Gemini CLI"
-        assert gemini_spec.config_relpath == Path(".gemini") / "mcp.json"
+        assert gemini_spec.config_relpath == Path(".gemini") / "settings.json"
         assert gemini_spec.config_key == "mcpServers"
         assert gemini_spec.needs_dir is True
         assert gemini_spec.cli_available is True

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -412,7 +412,7 @@ class TestFindMcpFiles:
         gemini_dir = repo_path / ".gemini"
         gemini_dir.mkdir()
 
-        mcp_file = gemini_dir / "mcp.json"
+        mcp_file = gemini_dir / "settings.json"
         mcp_data = {"mcpServers": {"Cicada": {}}}
         with open(mcp_file, "w") as f:
             json.dump(mcp_data, f)


### PR DESCRIPTION
Changes Gemini CLI MCP configuration file from .gemini/mcp.json to .gemini/settings.json to match Google's official Gemini CLI documentation.

This fixes the issue where cicada gemini command was writing to the wrong file location, preventing proper integration with Gemini CLI.

Fixes #121