### PR TITLE
Show coverage delta in CodeCov reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -31,6 +31,6 @@ ignore:
   - ".pytest_cache/**"
 
 comment:
-  layout: "diff, flags, files"
+  layout: "header, diff, flags, files"
   behavior: once
   require_changes: true


### PR DESCRIPTION
- Include 'header' in CodeCov comment layout to show coverage delta
- Header displays coverage change compared to base branch
- Provides better visibility into coverage trends

## Summary by Sourcery

Build:
- Update Codecov comment layout to add the header section for displaying coverage delta.