### PR TITLE
Update pull request trigger types in workflow

### DIFF
--- a/.github/workflows/codex-auto-review.yml
+++ b/.github/workflows/codex-auto-review.yml
@@ -1,7 +1,7 @@
 name: Auto Codex Review
 on:
   pull_request:
-    types: [opened, synchronize]  # Triggers on PR creation and new commits
+    types: [] #[opened, synchronize]  # Triggers on PR creation and new commits
 
 jobs:
   trigger-codex:

--- a/cicada/commands.py
+++ b/cicada/commands.py
@@ -1497,6 +1497,9 @@ def handle_server(args) -> None:
 
     try:
         asyncio.run(async_main())
+    except KeyboardInterrupt:
+        # Graceful shutdown on Ctrl+C, suppress traceback
+        pass
     finally:
         # Ensure watch process is stopped when server exits
         if watch_enabled:

--- a/cicada/mcp/entry.py
+++ b/cicada/mcp/entry.py
@@ -1,16 +1,23 @@
+import sys
+
 from cicada.entry_utils import run_cli
 
 
 def main() -> None:
     """Main entry point for cicada-mcp command."""
-    run_cli(
-        prog_name="cicada-mcp",
-        version_prog_name="cicada-mcp",
-        default_on_unknown="server",
-        default_on_none="server",
-        default_on_unknown_args=["--fast"],
-        default_on_none_args=["--fast"],
-    )
+
+    try:
+        run_cli(
+            prog_name="cicada-mcp",
+            version_prog_name="cicada-mcp",
+            default_on_unknown="server",
+            default_on_none="server",
+            default_on_unknown_args=["--fast"],
+            default_on_none_args=["--fast"],
+        )
+    except KeyboardInterrupt:
+        # Suppress traceback on Ctrl+C while allowing command-level cleanup
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/cicada/mcp/server.py
+++ b/cicada/mcp/server.py
@@ -146,15 +146,30 @@ class CicadaServer:
 
 async def async_main():
     """Async main entry point."""
+    import asyncio
+    from contextlib import suppress
 
-    # Set up signal handlers for clean shutdown
-    def signal_handler(signum, _frame):
-        """Handle signals by exiting cleanly."""
-        print(f"Received signal {signum}, shutting down...", file=sys.stderr)
-        sys.exit(0)
+    # Create a shutdown event for clean async cancellation
+    shutdown_event = asyncio.Event()
 
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
+    loop = asyncio.get_running_loop()
+
+    def request_shutdown() -> None:
+        """Signal the server to shut down."""
+
+        shutdown_event.set()
+
+    # Prefer asyncio-native signal handling to avoid race conditions
+    signals_to_handle = [signal.SIGINT]
+    if hasattr(signal, "SIGTERM"):
+        signals_to_handle.append(signal.SIGTERM)
+
+    for sig in signals_to_handle:
+        try:
+            loop.add_signal_handler(sig, request_shutdown)
+        except (NotImplementedError, RuntimeError):
+            # Fallback for platforms without add_signal_handler support
+            signal.signal(sig, lambda *_: loop.call_soon_threadsafe(request_shutdown))
 
     try:
         # Check if setup is needed before starting server
@@ -162,21 +177,44 @@ async def async_main():
         original_stdout = sys.stdout
         try:
             sys.stdout = sys.stderr
-            _auto_setup_if_needed()
+            _auto_setup_if_needed(shutdown_event)
         finally:
             sys.stdout = original_stdout
 
+        if shutdown_event.is_set():
+            return
+
         server = CicadaServer()
-        await server.run()
-    except KeyboardInterrupt:
-        print("Server interrupted, shutting down...", file=sys.stderr)
-        sys.exit(0)
+
+        # Run server with shutdown event monitoring
+        server_task = asyncio.create_task(server.run())
+        shutdown_task = asyncio.create_task(shutdown_event.wait())
+
+        # Wait for either server completion or shutdown signal
+        done, pending = await asyncio.wait(
+            [server_task, shutdown_task], return_when=asyncio.FIRST_COMPLETED
+        )
+
+        # Propagate exceptions from completed tasks
+        for task in done:
+            if task.cancelled():
+                continue
+            exception = task.exception()
+            if exception:
+                raise exception
+
+        # Cancel any remaining tasks (e.g., server_task during shutdown)
+        for task in pending:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
     except Exception as e:
         print(f"Error starting server: {e}", file=sys.stderr)
         sys.exit(1)
 
 
-def _auto_setup_if_needed():
+def _auto_setup_if_needed(shutdown_event=None):
     """
     Automatically run setup if the repository hasn't been indexed yet.
 
@@ -189,6 +227,12 @@ def _auto_setup_if_needed():
         get_config_path,
         get_index_path,
     )
+
+    def _ensure_not_shutdown():
+        if shutdown_event and shutdown_event.is_set():
+            raise KeyboardInterrupt
+
+    _ensure_not_shutdown()
 
     # Determine repository path from environment or current directory
     repo_path_str = None
@@ -223,18 +267,26 @@ def _auto_setup_if_needed():
     # Validate it's a supported project type
     from cicada.setup import detect_project_language
 
+    _ensure_not_shutdown()
+
     try:
         language = detect_project_language(repo_path)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
+    _ensure_not_shutdown()
+
     try:
         # Create storage directory
         storage_dir = create_storage_dir(repo_path)
 
+        _ensure_not_shutdown()
+
         # Index repository (silent mode)
         index_repository(repo_path, language, verbose=False)
+
+        _ensure_not_shutdown()
 
         # Create config.yaml (silent mode)
         create_config_yaml(repo_path, storage_dir, verbose=False)
@@ -265,7 +317,11 @@ def main():
         os.environ["CICADA_CONFIG_DIR"] = str(storage_dir)
         os.environ["_CICADA_REPO_PATH_ARG"] = str(abs_path)
 
-    asyncio.run(async_main())
+    try:
+        asyncio.run(async_main())
+    except KeyboardInterrupt:
+        # Suppress traceback on Ctrl+C, exit cleanly
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/cicada/scoring.py
+++ b/cicada/scoring.py
@@ -28,6 +28,37 @@ Z_SCORE_POOR_THRESHOLD = -1.0  # 16th percentile (>1σ below mean)
 # Module match boost value
 MODULE_MATCH_BOOST = 2.0
 
+# Exact name match score (for function/module name matches)
+# This is a high score awarded when a query keyword exactly matches the function/module name
+# (e.g., searching for "__init__" matches the __init__ function)
+EXACT_NAME_MATCH_SCORE = 3.0
+
+
+def _extract_simple_name(doc_name: str | None) -> str | None:
+    """
+    Extract the simple function/module name from a qualified name.
+
+    Handles qualified names with optional arity suffix:
+    - "MyApp.User.create_user/2" -> "create_user"
+    - "MyApp.User.__init__/1" -> "__init__"
+    - "create_user/2" -> "create_user"
+    - "MyApp.User" -> "user"
+
+    Note: The result is lowercased for case-insensitive matching.
+
+    Args:
+        doc_name: Qualified name, optionally with /N arity suffix
+
+    Returns:
+        Lowercased simple name (last part after dots), or None if doc_name is None
+    """
+    if not doc_name:
+        return None
+    # Remove arity suffix first (/N)
+    name_without_arity = doc_name.split("/")[0]
+    # Then get the last part after dots
+    return name_without_arity.split(".")[-1].lower()
+
 
 def _build_score_result(
     total_score: float,
@@ -125,14 +156,8 @@ def calculate_score(
     # Track how many times each query keyword has matched (for diminishing returns)
     keyword_match_counts: defaultdict[str, int] = defaultdict(int)
 
-    # Extract the simple name (last part after dots and slashes) for matching
-    # e.g., "MyApp.User.create_user/2" -> "create_user"
-    simple_name = None
-    if doc_name:
-        # Remove arity suffix first (/N)
-        name_without_arity = doc_name.split("/")[0]
-        # Then get the last part after dots
-        simple_name = name_without_arity.split(".")[-1].lower()
+    # Extract the simple name for exact name matching
+    simple_name = _extract_simple_name(doc_name)
 
     for query_kw, group_idx in zip(query_keywords, keyword_groups, strict=False):
         weight = None
@@ -140,7 +165,7 @@ def calculate_score(
             weight = doc_keywords[query_kw]
         elif simple_name and query_kw == simple_name:
             # Use a high score for exact name matches (equivalent to top keyword weight)
-            weight = 3.0
+            weight = EXACT_NAME_MATCH_SCORE
 
         if weight is not None:
             matched_keywords.append(query_kw)
@@ -201,11 +226,8 @@ def calculate_wildcard_score(
     # Track how many times each query keyword has matched (for diminishing returns)
     keyword_match_counts: defaultdict[str, int] = defaultdict(int)
 
-    # Extract the simple name (last part after dots and slashes) for matching
-    simple_name = None
-    if doc_name:
-        name_without_arity = doc_name.split("/")[0]
-        simple_name = name_without_arity.split(".")[-1].lower()
+    # Extract the simple name for wildcard name matching
+    simple_name = _extract_simple_name(doc_name)
 
     for query_kw, group_idx in zip(query_keywords, keyword_groups, strict=False):
         matched = False
@@ -238,7 +260,7 @@ def calculate_wildcard_score(
             # Apply diminishing returns to exact name matches
             match_count = keyword_match_counts[query_kw]
             diminishing_factor = 0.5**match_count
-            base_score += 3.0 * diminishing_factor
+            base_score += EXACT_NAME_MATCH_SCORE * diminishing_factor
 
             # Increment match count
             keyword_match_counts[query_kw] += 1

--- a/tests/mcp/test_graceful_shutdown.py
+++ b/tests/mcp/test_graceful_shutdown.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Tests for graceful shutdown behavior in MCP server."""
+
+import asyncio
+import signal
+from typing import Callable
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_shutdown_event_cancels_server_task(monkeypatch):
+    """SIGINT should trigger shutdown_event and cancel the running server task."""
+    from cicada.mcp import server as server_module
+
+    # Capture signal callbacks registered by async_main
+    loop = asyncio.get_running_loop()
+    registered_handlers: dict[signal.Signals, Callable[[], None]] = {}
+
+    def track_add_signal_handler(sig, callback):
+        registered_handlers[sig] = callback
+
+    monkeypatch.setattr(loop, "add_signal_handler", track_add_signal_handler)
+
+    # Mock server that waits indefinitely until cancelled
+    with patch.object(server_module, "CicadaServer") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        server_started = asyncio.Event()
+
+        async def mock_run():
+            server_started.set()
+            await asyncio.Event().wait()
+
+        mock_server.run = AsyncMock(side_effect=mock_run)
+
+        with patch.object(server_module, "_auto_setup_if_needed"):
+            main_task = asyncio.create_task(server_module.async_main())
+
+            await asyncio.wait_for(server_started.wait(), timeout=1.0)
+
+            # Simulate SIGINT delivery
+            assert signal.SIGINT in registered_handlers
+            registered_handlers[signal.SIGINT]()
+
+            await asyncio.wait_for(main_task, timeout=1.0)
+
+    assert main_task.done()
+    assert not main_task.cancelled()
+    assert mock_server.run.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_server_exception_propagates_to_sys_exit(monkeypatch):
+    """Exceptions from server.run should trigger sys.exit(1)."""
+    from cicada.mcp import server as server_module
+
+    with patch.object(server_module, "CicadaServer") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_server.run = AsyncMock(side_effect=RuntimeError("Test server error"))
+
+        with patch.object(server_module, "_auto_setup_if_needed"):
+            with patch("sys.exit") as mock_exit:
+                await server_module.async_main()
+
+    mock_exit.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_signal_handlers_use_asyncio_loop(monkeypatch):
+    """async_main should register signal handlers via the running loop."""
+    from cicada.mcp import server as server_module
+
+    loop = asyncio.get_running_loop()
+    signals_registered: list[signal.Signals] = []
+
+    def record_handler(sig, _callback):
+        signals_registered.append(sig)
+
+    monkeypatch.setattr(loop, "add_signal_handler", record_handler)
+
+    with patch.object(server_module, "CicadaServer") as mock_server_class:
+        mock_server = mock_server_class.return_value
+        mock_server.run = AsyncMock(return_value=None)
+
+        with patch.object(server_module, "_auto_setup_if_needed"):
+            await server_module.async_main()
+
+    assert signal.SIGINT in signals_registered
+    if hasattr(signal, "SIGTERM"):
+        assert signal.SIGTERM in signals_registered
+
+
+@pytest.mark.asyncio
+async def test_shutdown_requested_during_setup_aborts(monkeypatch):
+    """_auto_setup_if_needed should stop early when shutdown is requested."""
+    from cicada.mcp import server as server_module
+
+    shutdown_event = asyncio.Event()
+    shutdown_event.set()
+
+    with (
+        patch("cicada.setup.detect_project_language") as detect_language,
+        patch("cicada.utils.create_storage_dir") as create_storage,
+        patch("cicada.setup.index_repository") as index_repo,
+        patch("cicada.setup.create_config_yaml") as create_config,
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            server_module._auto_setup_if_needed(shutdown_event)
+
+    detect_language.assert_not_called()
+    create_storage.assert_not_called()
+    index_repo.assert_not_called()
+    create_config.assert_not_called()

--- a/tests/test_dunder_method_search.py
+++ b/tests/test_dunder_method_search.py
@@ -106,6 +106,23 @@ def test_module_name_not_confused_with_function_name():
     assert result["score"] == 0.0, "Should not match module name"
 
 
+def _assert_function_search(searcher, query_keyword, expected_function, expected_score=None):
+    """
+    Helper to search for a function and assert expected results.
+
+    Args:
+        searcher: KeywordSearcher instance
+        query_keyword: Keyword to search for
+        expected_function: Expected function name in results
+        expected_score: Optional expected score (if None, score check is skipped)
+    """
+    results = searcher.search([query_keyword], top_n=10, filter_type="functions")
+    assert len(results) == 1, f"Should find {expected_function} method"
+    assert results[0]["function"] == expected_function, f"Should match {expected_function}"
+    if expected_score is not None:
+        assert results[0]["score"] == expected_score, f"Should have score {expected_score}"
+
+
 def test_keyword_search_with_dunder_methods():
     """Integration test with KeywordSearcher."""
     # Create a simple index with dunder methods


### PR DESCRIPTION
## Summary by Sourcery

Improve graceful shutdown behavior for the MCP server and CLI while refining search scoring for exact function name matches and extending test coverage.

Bug Fixes:
- Ensure MCP server and CLI exit cleanly on shutdown signals and Ctrl+C without leaving hanging tasks or noisy tracebacks.

Enhancements:
- Introduce asyncio-based signal handling and shutdown event coordination in the MCP server for more robust, cancellable startup and runtime behavior.
- Allow automatic setup to be aborted early when shutdown is requested, preventing unnecessary indexing work.
- Refactor scoring logic to centralize simple-name extraction and use a shared constant for exact name match weighting in keyword and wildcard searches.
- Make the cicada-mcp and server command entry points gracefully handle KeyboardInterrupt to provide a cleaner user experience.

CI:
- Disable the Auto Codex Review workflow trigger by clearing pull_request types.

Tests:
- Add comprehensive tests for MCP server graceful shutdown behavior, including signal handling, exception propagation, and early-abort during setup.
- Add a helper in dunder method search tests to simplify repeated assertions for function search results.