### PR TITLE
Use asterisk keyword highlights in non-TTY output

### DIFF
--- a/cicada/query/context_extractor.py
+++ b/cicada/query/context_extractor.py
@@ -3,7 +3,7 @@ Utilities for extracting and formatting contextual text snippets from matched ke
 
 This module provides functions to:
 - Extract paragraphs containing matched keywords
-- Highlight keywords with bold/color formatting
+- Highlight keywords with asterisk or markdown formatting
 - Smart truncation of long strings
 - Combine multiple keyword matches into unified excerpts
 """
@@ -89,12 +89,12 @@ def extract_multiple_keywords(text: str, keywords: list[str]) -> str | None:
 
 def highlight_keywords(text: str, keywords: list[str], use_ansi: bool = True) -> str:
     """
-    Highlight keywords in text using bold formatting or ANSI colors.
+    Highlight keywords in text using single or double asterisks.
 
     Args:
         text: The text to highlight keywords in
         keywords: List of keywords to highlight
-        use_ansi: If True, use ANSI color codes; if False, use markdown bold
+        use_ansi: If True, wrap keywords in *; if False, use markdown bold
 
     Returns:
         Text with highlighted keywords
@@ -104,8 +104,24 @@ def highlight_keywords(text: str, keywords: list[str], use_ansi: bool = True) ->
 
     sorted_keywords = sorted(keywords, key=len, reverse=True)
 
-    start_mark = "\033[1;33m" if use_ansi else "**"
-    end_mark = "\033[0m" if use_ansi else "**"
+    start_mark = "*" if use_ansi else "**"
+    end_mark = "*" if use_ansi else "**"
+
+    def is_inside_existing_highlight(source: str, index: int) -> bool:
+        """Avoid double-wrapping already-highlighted text."""
+        if start_mark == end_mark:
+            return source[:index].count(start_mark) % 2 == 1
+
+        last_start = source.rfind(start_mark, 0, index)
+        if last_start == -1:
+            return False
+
+        last_end = source.rfind(end_mark, 0, index)
+        if last_end > last_start:
+            return False
+
+        next_end = source.find(end_mark, index)
+        return next_end != -1 and last_start < index < next_end
 
     result = text
     for keyword in sorted_keywords:
@@ -114,16 +130,8 @@ def highlight_keywords(text: str, keywords: list[str], use_ansi: bool = True) ->
         matches = []
         for match in pattern.finditer(result):
             start = match.start()
-            before_text = result[:start]
-
-            if use_ansi:
-                start_count = before_text.count(start_mark)
-                end_count = before_text.count(end_mark)
-                if start_count > end_count:
-                    continue
-            else:
-                if before_text.count(start_mark) % 2 == 1:
-                    continue
+            if is_inside_existing_highlight(result, start):
+                continue
 
             matches.append(match)
 
@@ -235,6 +243,7 @@ def format_matched_context(
     if doc_keywords and doc_text and (para := extract_multiple_keywords(doc_text, doc_keywords)):
         highlighted = highlight_keywords(para, doc_keywords, use_ansi)
         sections.append(f"Matched in documentation:\n> {highlighted}")
+
     # Format string literal matches
     if string_keywords and string_sources:
         relevant_strings = []

--- a/tests/query/test_context_extractor.py
+++ b/tests/query/test_context_extractor.py
@@ -145,12 +145,11 @@ class TestHighlightKeywords:
         assert "**authentication**" in result
 
     def test_ansi_highlighting(self):
-        """Test highlighting with ANSI colors."""
+        """Test highlighting with single asterisks."""
         text = "This paragraph mentions authentication."
         result = highlight_keywords(text, ["authentication"], use_ansi=True)
-        # Should contain ANSI escape codes
-        assert "\033[" in result
-        assert "authentication" in result
+        assert "*authentication*" in result
+        assert "\033[" not in result
 
     def test_multiple_keywords(self):
         """Test highlighting multiple keywords."""
@@ -193,10 +192,10 @@ class TestHighlightKeywords:
         assert "**user authentication**" in result
 
     def test_ansi_highlight_skips_existing_markers(self):
-        """Ensure ANSI highlighting does not double-wrap existing highlights."""
-        highlighted = "\033[1;33mauthentication\033[0m is present"
+        """Ensure highlighting does not double-wrap existing highlights."""
+        highlighted = "*authentication* is present"
         result = highlight_keywords(highlighted, ["authentication"], use_ansi=True)
-        assert result.count("\033[1;33m") == 1
+        assert result.count("*authentication*") == 1
 
 
 class TestSmartTruncateString:
@@ -388,7 +387,7 @@ class TestFormatMatchedContext:
         assert result.count("(line") <= 3
 
     def test_ansi_highlighting_in_context(self):
-        """Test that ANSI highlighting is applied when use_ansi=True."""
+        """Test that single-asterisk highlighting is applied when use_ansi=True."""
         matched_keywords = ["test"]
         keyword_sources = {"test": "docs"}
         doc_text = "This is a test module."
@@ -398,8 +397,8 @@ class TestFormatMatchedContext:
             matched_keywords, keyword_sources, doc_text, string_sources, use_ansi=True
         )
 
-        # Should contain ANSI escape codes
-        assert "\033[" in result
+        assert "*test*" in result
+        assert "\033[" not in result
 
     def test_long_string_truncation_in_context(self):
         """Test that long strings are truncated in the formatted context."""


### PR DESCRIPTION
## Summary by Sourcery

Switch keyword highlighting to use asterisk-based markers instead of ANSI color codes and update context formatting accordingly.

Bug Fixes:
- Ensure keyword highlighting logic skips already highlighted segments to avoid double-wrapping.

Enhancements:
- Change TTY/non-TTY keyword highlighting to use single or double asterisks rather than ANSI escape codes.

Documentation:
- Update context extractor module documentation to describe asterisk/Markdown-based keyword highlighting.

Tests:
- Adjust context extractor tests to validate asterisk-based highlighting and the absence of ANSI escape codes in non-TTY output.