### PR TITLE
Fix: First Time Linked Repo Bug

### DIFF
--- a/cicada/mcp/config_manager.py
+++ b/cicada/mcp/config_manager.py
@@ -36,9 +36,12 @@ class ConfigManager:
                     with open(link_file) as f:
                         link_data = yaml.safe_load(f)
                         if link_data and "source_storage_dir" in link_data:
-                            # Use the source storage directory's config
-                            return str(Path(link_data["source_storage_dir"]) / "config.yaml")
-                except (yaml.YAMLError, OSError, KeyError):
+                            source_dir = link_data["source_storage_dir"]
+                            # Validate value is a non-empty string
+                            if isinstance(source_dir, str) and source_dir.strip():
+                                # Use the source storage directory's config
+                                return str(Path(source_dir) / "config.yaml")
+                except (yaml.YAMLError, OSError, KeyError, TypeError):
                     # If link is corrupted, fall through to using config_dir directly
                     pass
 

--- a/tests/mcp/test_config_manager.py
+++ b/tests/mcp/test_config_manager.py
@@ -91,6 +91,86 @@ class TestGetConfigPath:
         # Should fall back to linked storage config path
         assert result == str(linked_storage / "config.yaml")
 
+    def test_falls_back_when_source_storage_dir_is_null(self, monkeypatch, tmp_path):
+        """Test that link.yaml with null source_storage_dir falls back."""
+        linked_storage = tmp_path / "linked_storage"
+        linked_storage.mkdir()
+        link_file = linked_storage / "link.yaml"
+        link_data = {
+            "source_repo_path": "/source/repo",
+            "source_storage_dir": None,
+            "linked_at": "2025-11-24T12:00:00",
+        }
+        with open(link_file, "w") as f:
+            yaml.dump(link_data, f)
+
+        monkeypatch.setenv("CICADA_CONFIG_DIR", str(linked_storage))
+
+        result = ConfigManager.get_config_path()
+
+        # Should fall back to linked storage config path
+        assert result == str(linked_storage / "config.yaml")
+
+    def test_falls_back_when_source_storage_dir_is_empty_string(self, monkeypatch, tmp_path):
+        """Test that link.yaml with empty source_storage_dir falls back."""
+        linked_storage = tmp_path / "linked_storage"
+        linked_storage.mkdir()
+        link_file = linked_storage / "link.yaml"
+        link_data = {
+            "source_repo_path": "/source/repo",
+            "source_storage_dir": "",
+            "linked_at": "2025-11-24T12:00:00",
+        }
+        with open(link_file, "w") as f:
+            yaml.dump(link_data, f)
+
+        monkeypatch.setenv("CICADA_CONFIG_DIR", str(linked_storage))
+
+        result = ConfigManager.get_config_path()
+
+        # Should fall back to linked storage config path
+        assert result == str(linked_storage / "config.yaml")
+
+    def test_falls_back_when_source_storage_dir_is_whitespace(self, monkeypatch, tmp_path):
+        """Test that link.yaml with whitespace-only source_storage_dir falls back."""
+        linked_storage = tmp_path / "linked_storage"
+        linked_storage.mkdir()
+        link_file = linked_storage / "link.yaml"
+        link_data = {
+            "source_repo_path": "/source/repo",
+            "source_storage_dir": "   ",
+            "linked_at": "2025-11-24T12:00:00",
+        }
+        with open(link_file, "w") as f:
+            yaml.dump(link_data, f)
+
+        monkeypatch.setenv("CICADA_CONFIG_DIR", str(linked_storage))
+
+        result = ConfigManager.get_config_path()
+
+        # Should fall back to linked storage config path
+        assert result == str(linked_storage / "config.yaml")
+
+    def test_falls_back_when_source_storage_dir_is_number(self, monkeypatch, tmp_path):
+        """Test that link.yaml with non-string source_storage_dir falls back."""
+        linked_storage = tmp_path / "linked_storage"
+        linked_storage.mkdir()
+        link_file = linked_storage / "link.yaml"
+        link_data = {
+            "source_repo_path": "/source/repo",
+            "source_storage_dir": 12345,
+            "linked_at": "2025-11-24T12:00:00",
+        }
+        with open(link_file, "w") as f:
+            yaml.dump(link_data, f)
+
+        monkeypatch.setenv("CICADA_CONFIG_DIR", str(linked_storage))
+
+        result = ConfigManager.get_config_path()
+
+        # Should fall back to linked storage config path
+        assert result == str(linked_storage / "config.yaml")
+
     def test_uses_workspace_folder_paths_single_path(self, monkeypatch):
         """Test WORKSPACE_FOLDER_PATHS with a single path."""
         workspace_path = "/home/user/project"


### PR DESCRIPTION
## Summary by Sourcery

Handle linked configuration directories and expand TypeScript support coverage and documentation.

Bug Fixes:
- Resolve CICADA_CONFIG_DIR paths through link.yaml when present, falling back safely if the link metadata is invalid or incomplete.

Documentation:
- Add user-facing documentation describing CICADA's TypeScript support, capabilities, limitations, and usage.
- Document the structure and usage of the TypeScript test suite for contributors.

Tests:
- Add unit tests for resolving linked configuration directories and graceful fallback when link metadata is corrupted or incomplete.
- Introduce a comprehensive TypeScript test suite and fixtures to validate indexing of interfaces, enums, generics, async patterns, imports/exports, documentation, and cross-file analysis.