### PR TITLE
Clean up tests that take too long

### DIFF
--- a/tests/mcp/test_index_manager.py
+++ b/tests/mcp/test_index_manager.py
@@ -293,6 +293,9 @@ class TestBackgroundRefreshManager:
 
     def test_debounce_coalesces_requests(self, refresh_manager, mock_index_manager):
         """Test that multiple rapid requests are debounced."""
+        # Use a short debounce for faster test execution
+        refresh_manager.DEBOUNCE_SECONDS = 0.1
+
         with patch.object(refresh_manager, "_execute_refresh") as mock_execute:
             # Make multiple rapid schedule requests
             refresh_manager._schedule_refresh()
@@ -303,7 +306,7 @@ class TestBackgroundRefreshManager:
             assert refresh_manager._debounce_timer is not None
 
             # Wait for debounce to complete
-            time.sleep(refresh_manager.DEBOUNCE_SECONDS + 0.5)
+            time.sleep(refresh_manager.DEBOUNCE_SECONDS + 0.1)
 
             # Should have been called only once
             assert mock_execute.call_count == 1

--- a/tests/watcher/test_watch_manager.py
+++ b/tests/watcher/test_watch_manager.py
@@ -483,7 +483,7 @@ class TestMCPWatchIntegration:
         assert get_watch_manager() is None, "Global watch manager should be cleared"
 
         # Give process a moment to terminate
-        time.sleep(0.5)
+        time.sleep(0.2)
 
         # Verify process is no longer running by checking if PID exists
         try:

--- a/tests/watcher/test_watcher.py
+++ b/tests/watcher/test_watcher.py
@@ -349,7 +349,7 @@ class TestFileWatcher:
             reindex_count.append(1)
 
         watcher = FileWatcher(
-            repo_path=str(elixir_repo), register_signal_handlers=False, debounce_seconds=0.2
+            repo_path=str(elixir_repo), register_signal_handlers=False, debounce_seconds=0.05
         )
         watcher._trigger_reindex = mock_trigger_reindex
 
@@ -359,10 +359,10 @@ class TestFileWatcher:
         # Trigger multiple changes rapidly
         for _ in range(5):
             watcher._on_file_change(event)
-            time.sleep(0.05)  # 50ms between changes
+            time.sleep(0.01)  # 10ms between changes
 
         # Wait for debounce to expire
-        time.sleep(0.3)
+        time.sleep(0.1)
 
         # Should have only triggered once
         assert len(reindex_count) == 1
@@ -504,7 +504,7 @@ class TestFileWatcherIntegration:
         watcher = FileWatcher(
             repo_path=str(elixir_repo),
             verbose=False,
-            debounce_seconds=0.5,
+            debounce_seconds=0.15,  # Reduced from 0.5s for faster test
             register_signal_handlers=False,
         )
 
@@ -525,7 +525,7 @@ class TestFileWatcherIntegration:
 
         try:
             # Wait a moment for observer to be ready
-            time.sleep(0.3)
+            time.sleep(0.1)  # Reduced from 0.3s
 
             # Create a new .ex file
             test_file = elixir_repo / "lib" / "new_module.ex"
@@ -538,7 +538,7 @@ end
             )
 
             # Wait for file event detection + debounce + reindex trigger
-            success = reindex_called.wait(timeout=3)
+            success = reindex_called.wait(timeout=1)  # Reduced from 3s
             assert success, "Reindex should be triggered by real file change"
 
         finally:


### PR DESCRIPTION
- Reduce DEBOUNCE_SECONDS from 2.0s to 0.1s in test_debounce_coalesces_requests
- Reduce debounce_seconds from 0.5s to 0.15s in file watcher integration test
- Reduce sleep times in test_multiple_rapid_changes_debounce_correctly
- Reduce process termination wait from 0.5s to 0.2s

Saves ~3.5s from test suite execution time.

## Summary by Sourcery

Tests:
- Reduce debounce intervals, sleep durations, and wait timeouts in watcher and index manager tests to significantly decrease test suite execution time.