### PR TITLE
Add comparison to alternatives section and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,26 +45,6 @@ Instead of raw text dumps, CICADA gives your AI **structured, pre-indexed knowle
 
 ---
 
-## Comparison to Alternatives
-
-| Feature | CICADA | [Serena](https://github.com/oraios/serena) | [Codicil](https://github.com/E-xyza/codicil) (Elixir-only) |
-|---------|--------|--------|---------|
-| **Analysis Method** | SCIP (static index) | LSP (real-time server) | LLM summaries + embeddings |
-| **Code Editing** | ❌ | ✅ | ❌ |
-| **Git Context** | ✅ PR history, blame, evolution | ❌ | ❌ |
-| **Resource Usage** | Low (read from disk) | High (persistent server processes) | Medium (API calls) |
-| **Privacy** | 100% local | 100% local | Requires external LLM APIs |
-| **Semantic Search** | Local Ollama or keywords | ❌ | OpenAI/Anthropic embeddings |
-| **Call Graph** | Bidirectional with alias resolution | LSP-based | ❌ |
-
-**When to choose CICADA:** You want local-first operation with rich git context (PR attribution, blame, function evolution tracking) and efficient token usage.
-
-**When to choose Serena:** You need code editing capabilities through LSP and can accept higher resource usage.
-
-**When to choose Codicil:** You have an Elixir project and prefer LLM-powered semantic summaries (Elixir-only).
-
----
-
 ## Install
 
 ```bash
@@ -470,6 +450,26 @@ All tools return structured Markdown/JSON snippets (signatures, call sites, PR m
 - 🚧 C#/Visual Basic (SCIP)
 - 🚧 Dart (SCIP)
 - 🚧 PHP (SCIP)
+
+---
+
+## Comparison to Alternatives
+
+| Feature | CICADA | [Serena](https://github.com/oraios/serena) | [Codicil](https://github.com/E-xyza/codicil) (Elixir-only) |
+|---------|--------|--------|---------|
+| **Analysis Method** | SCIP (static index) | LSP (real-time server) | LLM summaries + embeddings |
+| **Code Editing** | ❌ | ✅ | ❌ |
+| **Git Context** | ✅ PR history, blame, evolution | ❌ | ❌ |
+| **Resource Usage** | Low (read from disk) | High (persistent server processes) | Medium (API calls) |
+| **Privacy** | 100% local | 100% local | Requires external LLM APIs |
+| **Semantic Search** | Local Ollama or keywords | ❌ | OpenAI/Anthropic embeddings |
+| **Call Graph** | Bidirectional with alias resolution | LSP-based | ❌ |
+
+**When to choose CICADA:** You want local-first operation with rich git context (PR attribution, blame, function evolution tracking) and efficient token usage.
+
+**When to choose Serena:** You need code editing capabilities through LSP and can accept higher resource usage.
+
+**When to choose Codicil:** You have an Elixir project and prefer LLM-powered semantic summaries (Elixir-only).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add comparison table comparing CICADA vs Serena vs Codicil
- Note that Codicil is Elixir-only
- Simplify hero section: reduce logo size, fewer badges
- Fix broken HTML details/summary structure
- Fix broken anchor links
- Remove duplicate horizontal rules
- Fix pre-existing type errors in elixir/__init__.py and index_manager.py

Closes #220