### PR TITLE
Fix cicada-core import error for PyPI installations

### DIFF
--- a/cicada/languages/formatter_interface.py
+++ b/cicada/languages/formatter_interface.py
@@ -1,5 +1,58 @@
-"""Formatter interface - re-export from cicada_core for backward compatibility."""
+"""
+Formatter interface for language-specific formatting.
 
-from cicada_core.formatter_interface import BaseLanguageFormatter
+Each language implementation should provide its own formatter
+that implements these methods.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseLanguageFormatter(ABC):
+    """
+    Abstract base class for language-specific formatters.
+
+    Each language (Elixir, Python, etc.) should implement this interface
+    to provide language-specific formatting rules.
+    """
+
+    @abstractmethod
+    def format_function_identifier(self, module_name: str, func_name: str, arity: int) -> str:
+        """
+        Format a function identifier in language-specific notation.
+
+        Args:
+            module_name: The module or class name
+            func_name: The function or method name
+            arity: The number of parameters
+
+        Returns:
+            Formatted function identifier string
+
+        Examples:
+            Elixir: "MyModule.my_func/2"
+            Python: "MyClass.my_method()"
+        """
+
+    @abstractmethod
+    def format_function_name(
+        self, func_name: str, arity: int, args: list[str] | None = None
+    ) -> str:
+        """
+        Format just the function name with args/arity (no module prefix).
+
+        Args:
+            func_name: The function or method name
+            arity: The number of parameters
+            args: Optional list of argument names
+
+        Returns:
+            Formatted function name string
+
+        Examples:
+            Elixir: "my_func(a, b)" or "my_func/2"
+            Python: "my_method(config)" or "my_method()"
+        """
+
 
 __all__ = ["BaseLanguageFormatter"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "cicada-core",
     # cicada-scip is optional - see [project.optional-dependencies]
     "mcp>=0.1.0",
     "pyyaml>=6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,6 @@ name = "cicada-mcp"
 version = "0.6.0"
 source = { editable = "." }
 dependencies = [
-    { name = "cicada-core" },
     { name = "cicada-vector" },
     { name = "fastapi" },
     { name = "gitpython" },
@@ -366,7 +365,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cicada-core", editable = "packages/cicada-core" },
     { name = "cicada-scip", marker = "extra == 'all'", editable = "packages/cicada-scip" },
     { name = "cicada-scip", marker = "extra == 'dev'", editable = "packages/cicada-scip" },
     { name = "cicada-scip", marker = "extra == 'scip'", editable = "packages/cicada-scip" },


### PR DESCRIPTION
The cicada-core package was declared as a dependency but never published
to PyPI. This caused ModuleNotFoundError when users installed cicada-mcp
from PyPI.

Fix by inlining the BaseLanguageFormatter class directly into
cicada/languages/formatter_interface.py and removing the cicada-core
dependency from pyproject.toml. The workspace package is only needed
for local development.

https://claude.ai/code/session_01NLwHhrfBj3mQofHvKtqjvr