### PR TITLE
Consolidate cicada-core into cicada-mcp

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -101,34 +101,6 @@ jobs:
           "
           cat cicada/_version_hash.py
 
-      # Build and publish cicada-core first (cicada-mcp depends on it)
-      - name: Build cicada-core
-        run: |
-          cd packages/cicada-core
-          uv build
-
-      - name: Publish cicada-core to TestPyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          cd packages/cicada-core
-          uv publish \
-            --publish-url https://test.pypi.org/legacy/ \
-            --token $UV_PUBLISH_TOKEN || echo "cicada-core may already exist on TestPyPI"
-
-      # Wait for cicada-core to be available on TestPyPI
-      - name: Wait for cicada-core availability
-        run: |
-          echo "Waiting for cicada-core to be available on TestPyPI..."
-          for i in {1..12}; do
-            if pip index versions cicada-core --index-url https://test.pypi.org/simple/ 2>/dev/null; then
-              echo "cicada-core is available!"
-              break
-            fi
-            echo "Attempt $i/12: Not yet available, waiting 10s..."
-            sleep 10
-          done
-
       # Build and publish cicada-mcp
       - name: Build cicada-mcp
         run: uv build
@@ -206,32 +178,6 @@ jobs:
           "
           cat cicada/_version_hash.py
 
-      # Build and publish cicada-core first (cicada-mcp depends on it)
-      - name: Build cicada-core
-        run: |
-          cd packages/cicada-core
-          uv build
-
-      - name: Publish cicada-core to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          cd packages/cicada-core
-          uv publish --token $UV_PUBLISH_TOKEN || echo "cicada-core version may already exist on PyPI"
-
-      # Wait for cicada-core to be available on PyPI
-      - name: Wait for cicada-core availability
-        run: |
-          echo "Waiting for cicada-core to be available on PyPI..."
-          for i in {1..12}; do
-            if pip index versions cicada-core 2>/dev/null; then
-              echo "cicada-core is available!"
-              break
-            fi
-            echo "Attempt $i/12: Not yet available, waiting 10s..."
-            sleep 10
-          done
-
       # Build and publish cicada-mcp
       - name: Build cicada-mcp
         run: uv build
@@ -306,32 +252,6 @@ jobs:
               f.write(f'GIT_TAG = \"{tag}\"\nGIT_COMMIT_HASH = \"{commit}\"\n')
           "
           cat cicada/_version_hash.py
-
-      # Build and publish cicada-core first (cicada-mcp depends on it)
-      - name: Build cicada-core
-        run: |
-          cd packages/cicada-core
-          uv build
-
-      - name: Publish cicada-core to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          cd packages/cicada-core
-          uv publish --token $UV_PUBLISH_TOKEN || echo "cicada-core version may already exist on PyPI"
-
-      # Wait for cicada-core to be available on PyPI
-      - name: Wait for cicada-core availability
-        run: |
-          echo "Waiting for cicada-core to be available on PyPI..."
-          for i in {1..12}; do
-            if pip index versions cicada-core 2>/dev/null; then
-              echo "cicada-core is available!"
-              break
-            fi
-            echo "Attempt $i/12: Not yet available, waiting 10s..."
-            sleep 10
-          done
 
       # Build and publish cicada-mcp
       - name: Build cicada-mcp

--- a/cicada/core/__init__.py
+++ b/cicada/core/__init__.py
@@ -1,0 +1,46 @@
+"""
+Cicada Core - Shared foundation for Cicada code intelligence.
+
+This module provides:
+- BaseIndexer: Abstract base class for all language indexers
+- BaseLanguageFormatter: Abstract base class for language formatters
+- Storage utilities: Path management for index files
+- Hash utilities: File hashing for incremental indexing
+"""
+
+from cicada.core.base_indexer import BaseIndexer
+from cicada.core.hash_utils import (
+    compute_file_hash,
+    compute_hashes_for_files,
+    detect_file_changes,
+    load_file_hashes,
+    save_file_hashes,
+)
+from cicada.core.storage import (
+    create_storage_dir,
+    get_config_path,
+    get_hashes_path,
+    get_index_path,
+    get_repo_hash,
+    get_storage_dir,
+)
+from cicada.languages.formatter_interface import BaseLanguageFormatter
+
+__all__ = [
+    # Base classes
+    "BaseIndexer",
+    "BaseLanguageFormatter",
+    # Hash utilities
+    "compute_file_hash",
+    "compute_hashes_for_files",
+    "detect_file_changes",
+    "load_file_hashes",
+    "save_file_hashes",
+    # Storage utilities
+    "get_repo_hash",
+    "get_storage_dir",
+    "create_storage_dir",
+    "get_index_path",
+    "get_config_path",
+    "get_hashes_path",
+]

--- a/cicada/core/base_indexer.py
+++ b/cicada/core/base_indexer.py
@@ -1,0 +1,178 @@
+"""
+Abstract base class for language-specific indexers.
+
+All language implementations must subclass BaseIndexer and implement the abstract methods.
+This is a minimal interface - enrichment (keywords, timestamps, cochange) is handled
+separately by the main cicada package.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class BaseIndexer(ABC):
+    """
+    Universal indexer interface for all programming languages.
+
+    Each language-specific indexer (e.g., ElixirIndexer, PythonSCIPIndexer) must
+    inherit from this class and implement all abstract methods.
+
+    The indexer is responsible for:
+    1. Finding source files in a repository
+    2. Parsing those files (language-specific)
+    3. Building the unified index structure
+    4. Returning the raw index (enrichment is done separately)
+    """
+
+    # Override this in subclasses that support incremental indexing
+    supports_incremental: bool = False
+
+    def __init__(self, verbose: bool = False):
+        """Initialize base indexer with common state."""
+        self.verbose = verbose
+
+    @abstractmethod
+    def get_language_name(self) -> str:
+        """
+        Return the language identifier for this indexer.
+
+        Returns:
+            Language name in lowercase (e.g., 'elixir', 'python', 'typescript')
+        """
+
+    @abstractmethod
+    def get_file_extensions(self) -> list[str]:
+        """
+        Return file extensions to index for this language.
+
+        Returns:
+            List of file extensions including dots (e.g., ['.ex', '.exs'], ['.py'])
+        """
+
+    @abstractmethod
+    def get_excluded_dirs(self) -> list[str]:
+        """
+        Return language-specific directories to exclude from indexing.
+
+        Returns:
+            List of directory names to exclude (e.g., ['deps', '_build'], ['__pycache__', '.venv'])
+        """
+
+    @abstractmethod
+    def index_repository(
+        self,
+        repo_path: str | Path,
+        output_path: str | Path,
+        force: bool = False,
+        verbose: bool = False,
+        config_path: str | Path | None = None,
+    ) -> dict:
+        """
+        Index a repository and return the raw index.
+
+        Args:
+            repo_path: Path to the repository to index
+            output_path: Path where the index.json should be saved
+            force: If True, reindex all files regardless of changes
+            verbose: If True, print detailed progress information
+            config_path: Optional path to config.yaml for custom settings
+
+        Returns:
+            Dictionary with indexing results:
+                {
+                    "success": bool,
+                    "modules_count": int,
+                    "functions_count": int,
+                    "files_indexed": int,
+                    "errors": list[str]
+                }
+        """
+
+    def incremental_index_repository(
+        self,
+        repo_path: str,
+        output_path: str,
+        force_full: bool = False,
+        verbose: bool = True,
+    ) -> dict:
+        """
+        Incrementally index a repository using file hashing.
+
+        This method is optional - only indexers that support incremental indexing
+        (supports_incremental = True) need to implement this.
+
+        Note: This returns a RAW index without enrichment. Enrichment (keywords,
+        timestamps, cochange) should be applied separately by the caller.
+
+        Args:
+            repo_path: Path to the repository root
+            output_path: Path where the index JSON file will be saved
+            force_full: If True, ignore existing hashes and do full reindex
+            verbose: If True, print detailed progress information
+
+        Returns:
+            Dictionary containing the raw index data
+
+        Raises:
+            NotImplementedError: If the indexer does not support incremental indexing
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support incremental indexing. "
+            f"Use index_repository() instead."
+        )
+
+    def _find_source_files(self, repo_path: Path) -> list[Path]:
+        """
+        Find all source files to index in the repository.
+
+        Default implementation finds files by extension and excludes
+        directories from get_excluded_dirs(). Can be overridden for
+        custom file discovery logic.
+
+        Args:
+            repo_path: Repository root path
+
+        Returns:
+            List of source file paths to index
+        """
+        source_files = []
+        extensions = self.get_file_extensions()
+        excluded = set(self.get_excluded_dirs())
+
+        for ext in extensions:
+            for file_path in repo_path.rglob(f"*{ext}"):
+                # Check if any parent directory is excluded
+                if any(part in excluded for part in file_path.parts):
+                    continue
+                if file_path.is_file():
+                    source_files.append(file_path)
+
+        return sorted(source_files)
+
+    def should_index_file(self, file_path: Path) -> bool:
+        """
+        Determine if a file should be indexed (optional override).
+
+        Default implementation returns True. Override to implement custom
+        filtering logic (e.g., skip files by pattern, check file size, etc.).
+
+        Args:
+            file_path: Path to check
+
+        Returns:
+            True if file should be indexed, False otherwise
+        """
+        return True
+
+    def get_default_config(self) -> dict:
+        """
+        Return default configuration for this language (optional override).
+
+        Returns:
+            Dictionary with default config values
+        """
+        return {
+            "language": self.get_language_name(),
+            "file_extensions": self.get_file_extensions(),
+            "excluded_dirs": self.get_excluded_dirs(),
+        }

--- a/cicada/core/hash_utils.py
+++ b/cicada/core/hash_utils.py
@@ -1,0 +1,178 @@
+"""
+Utilities for computing and managing file hashes for incremental indexing.
+
+This module provides MD5-based file hashing to detect changes in the codebase
+and enable incremental reindexing, avoiding reprocessing of unchanged files.
+"""
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def compute_file_hash(file_path: str) -> str:
+    """
+    Compute MD5 hash of a file's content.
+
+    Args:
+        file_path: Path to the file to hash
+
+    Returns:
+        MD5 hash as hexadecimal string
+
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        IOError: If file cannot be read
+    """
+    # Note: MD5 is used here for speed, not security. This is for content-based
+    # change detection, not cryptographic purposes. MD5 is significantly faster
+    # than SHA256 and collision risk is negligible for our use case.
+    hash_md5 = hashlib.md5()
+    try:
+        with open(file_path, "rb") as f:
+            # Read in chunks to handle large files efficiently
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_md5.update(chunk)
+        return hash_md5.hexdigest()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"File not found: {file_path}") from None
+    except Exception as e:
+        raise OSError(f"Error reading file {file_path}: {e}") from e
+
+
+def load_file_hashes(path: str) -> dict[str, str]:
+    """
+    Load file hashes from a hashes.json file.
+
+    Args:
+        path: Path to the hashes.json file OR the directory containing it.
+              If a directory is passed, appends 'hashes.json' for backwards compatibility.
+
+    Returns:
+        Dictionary mapping file paths to MD5 hashes.
+        Returns empty dict if hashes.json doesn't exist.
+    """
+    hashes_path = Path(path)
+    # Backwards compatibility: if directory passed, append hashes.json
+    if hashes_path.is_dir() or not str(path).endswith(".json"):
+        hashes_path = hashes_path / "hashes.json"
+
+    if not hashes_path.exists():
+        return {}
+
+    try:
+        with open(hashes_path, encoding="utf-8") as f:
+            data = json.load(f)
+            return data.get("hashes", {})
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Warning: Could not load hashes.json: {e}")
+        return {}
+
+
+def save_file_hashes(path: str, hashes: dict[str, str]) -> None:
+    """
+    Save file hashes to a hashes.json file.
+
+    Args:
+        path: Path to the hashes.json file OR the directory containing it.
+              If a directory is passed, appends 'hashes.json' for backwards compatibility.
+        hashes: Dictionary mapping file paths to MD5 hashes
+    """
+    hashes_path = Path(path)
+    # Backwards compatibility: if directory passed, append hashes.json
+    if hashes_path.is_dir() or not str(path).endswith(".json"):
+        hashes_path = hashes_path / "hashes.json"
+
+    # Ensure parent directory exists
+    os.makedirs(hashes_path.parent, exist_ok=True)
+
+    data = {
+        "version": "1.0",
+        "hashes": hashes,
+        "last_updated": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+    try:
+        with open(hashes_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError as e:
+        print(f"Warning: Could not save hashes.json: {e}")
+
+
+def detect_file_changes(
+    files: list[str], old_hashes: dict[str, str], repo_path: str | None = None
+) -> tuple[list[str], list[str], list[str]]:
+    """
+    Detect new, modified, and deleted files by comparing hashes.
+
+    Args:
+        files: List of current file paths (relative to repo root)
+        old_hashes: Dictionary of file paths to their previous MD5 hashes
+        repo_path: Optional repository root path. If provided, file paths
+                   will be resolved relative to this path.
+
+    Returns:
+        Tuple of (new_files, modified_files, deleted_files)
+        - new_files: Files that didn't exist in old_hashes
+        - modified_files: Files whose hash changed
+        - deleted_files: Files in old_hashes but not in current files list
+    """
+    new_files = []
+    modified_files = []
+
+    current_file_set = set(files)
+    old_file_set = set(old_hashes.keys())
+
+    # Detect deleted files
+    deleted_files = list(old_file_set - current_file_set)
+
+    # Detect new and modified files
+    for file_path in files:
+        # Resolve full path if repo_path provided
+        full_path = os.path.join(repo_path, file_path) if repo_path else file_path
+
+        if file_path not in old_hashes:
+            # New file
+            new_files.append(file_path)
+        else:
+            # Check if modified
+            # Note: Race condition possible if file modified between this check
+            # and actual indexing, but impact is minimal (re-detected next run)
+            try:
+                current_hash = compute_file_hash(full_path)
+                if current_hash != old_hashes[file_path]:
+                    modified_files.append(file_path)
+            except (OSError, FileNotFoundError) as e:
+                # File might have been deleted after listing
+                print(f"Warning: Could not hash {file_path}: {e}")
+                deleted_files.append(file_path)
+
+    return new_files, modified_files, deleted_files
+
+
+def compute_hashes_for_files(files: list[str], repo_path: str | None = None) -> dict[str, str]:
+    """
+    Compute MD5 hashes for a list of files.
+
+    Args:
+        files: List of file paths (relative to repo root)
+        repo_path: Optional repository root path. If provided, file paths
+                   will be resolved relative to this path.
+
+    Returns:
+        Dictionary mapping file paths to MD5 hashes
+    """
+    hashes = {}
+
+    for file_path in files:
+        # Resolve full path if repo_path provided
+        full_path = os.path.join(repo_path, file_path) if repo_path else file_path
+
+        try:
+            hashes[file_path] = compute_file_hash(full_path)
+        except (OSError, FileNotFoundError) as e:
+            print(f"Warning: Could not hash {file_path}: {e}")
+
+    return hashes

--- a/cicada/core/storage.py
+++ b/cicada/core/storage.py
@@ -1,0 +1,98 @@
+"""
+Storage management utilities for Cicada.
+
+Handles creation and management of storage directories for index files.
+This is the core storage module - linking functionality is in main cicada.
+"""
+
+import hashlib
+from pathlib import Path
+
+
+def get_repo_hash(repo_path: str | Path) -> str:
+    """
+    Generate a unique hash for a repository path.
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Hex string hash of the repository path (16 chars)
+    """
+    repo_path_str = str(Path(repo_path).resolve())
+    return hashlib.sha256(repo_path_str.encode()).hexdigest()[:16]
+
+
+def get_storage_dir(repo_path: str | Path) -> Path:
+    """
+    Get the storage directory for a repository.
+
+    Storage structure:
+        ~/.cicada/projects/<repo_hash>/
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Path to the storage directory for this repository
+    """
+    repo_hash = get_repo_hash(repo_path)
+    storage_dir = Path.home() / ".cicada" / "projects" / repo_hash
+    return storage_dir
+
+
+def create_storage_dir(repo_path: str | Path) -> Path:
+    """
+    Create the storage directory for a repository if it doesn't exist.
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Path to the created storage directory
+    """
+    storage_dir = get_storage_dir(repo_path)
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    return storage_dir
+
+
+def get_index_path(repo_path: str | Path) -> Path:
+    """
+    Get the path to the index file for a repository.
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Path to the index.json file
+    """
+    storage_dir = get_storage_dir(repo_path)
+    return storage_dir / "index.json"
+
+
+def get_config_path(repo_path: str | Path) -> Path:
+    """
+    Get the path to the config file for a repository.
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Path to the config.yaml file
+    """
+    storage_dir = get_storage_dir(repo_path)
+    return storage_dir / "config.yaml"
+
+
+def get_hashes_path(repo_path: str | Path) -> Path:
+    """
+    Get the path to the hashes file for a repository.
+
+    Args:
+        repo_path: Path to the repository
+
+    Returns:
+        Path to the hashes.json file
+    """
+    storage_dir = get_storage_dir(repo_path)
+    return storage_dir / "hashes.json"

--- a/cicada/languages/formatter_interface.py
+++ b/cicada/languages/formatter_interface.py
@@ -4,10 +4,8 @@ Formatter interface for language-specific formatting.
 Each language implementation should provide its own formatter
 that implements these methods.
 
-Note: This class is inlined here (rather than imported from cicada-core) so that
-cicada-mcp can be installed standalone without requiring cicada-core. The canonical
-source is packages/cicada-core/src/cicada_core/formatter_interface.py - keep both
-in sync if changes are needed.
+This is the canonical source for BaseLanguageFormatter. The cicada.core module
+re-exports this class for convenience.
 """
 
 from abc import ABC, abstractmethod

--- a/codebook/tasks/202601281417-PUBLISH_CICADA_CORE.md
+++ b/codebook/tasks/202601281417-PUBLISH_CICADA_CORE.md
@@ -1,106 +1,78 @@
 ---
 reviewed:
-- .github/workflows/publish-pypi.yml:80eeec601bed5289e99a8e2f08545307bc764ecb
+- .github/workflows/publish-pypi.yml
+- cicada/core/__init__.py
+- cicada/core/base_indexer.py
+- cicada/core/hash_utils.py
+- cicada/core/storage.py
+- packages/cicada-scip/pyproject.toml
+- packages/cicada-scip/src/cicada_scip/indexer.py
+- packages/cicada-scip/src/cicada_scip/formatter.py
 ---
 
-# Publish cicada-core to PyPI
+# Consolidate cicada-core into cicada-mcp
 
 This document describes the changes made to fix the `ModuleNotFoundError` when installing `cicada-mcp` from PyPI.
 
 ## Problem
 
-The `cicada-core` package was declared as a dependency in `pyproject.toml` but never published to PyPI. When users installed `cicada-mcp` from PyPI:
+The `cicada-core` package was declared as a dependency but:
+1. Was never published to PyPI
+2. The name `cicada-core` is already taken on PyPI by another project (a CI/CD tool)
 
-```bash
-pip install cicada-mcp
-# or
-uv tool install cicada-mcp
-```
-
-They would get:
-
+When users installed `cicada-mcp` from PyPI, they would get:
 ```
 ModuleNotFoundError: No module named 'cicada_core'
 ```
 
-This happened because:
-1. `cicada-mcp` depends on `cicada-core` (declared in `pyproject.toml`)
-2. `cicada-core` is a workspace package under `packages/cicada-core/`
-3. UV's workspace feature resolves it locally during development
-4. But the publish workflow only published `cicada-mcp`, not `cicada-core`
-5. PyPI couldn't find `cicada-core` since it was never published
-
 ## Solution
 
-Updated `.github/workflows/publish-pypi.yml` to publish `cicada-core` before `cicada-mcp`.
+Instead of publishing a separate `cicada-core` package, we consolidated all shared code into `cicada-mcp` directly:
 
-### Changes to Publish Workflow
+1. **Created `cicada/core/` module** with all shared code:
+   - `base_indexer.py` - BaseIndexer ABC
+   - `hash_utils.py` - File hashing for incremental indexing
+   - `storage.py` - Storage path utilities
+   - `__init__.py` - Exports all utilities
 
-All three publish jobs were updated:
-- `test-publish` (TestPyPI)
-- `publish` (PyPI after TestPyPI)
-- `publish-direct` (PyPI direct)
+2. **Updated `cicada-scip`** to import from `cicada.core` instead of `cicada_core`
 
-Each job now:
+3. **Updated `cicada-scip` dependency** from `cicada-core>=0.1.0` to `cicada-mcp>=0.6.0`
 
-1. **Builds cicada-core first**
-   ```yaml
-   - name: Build cicada-core
-     run: |
-       cd packages/cicada-core
-       uv build
-   ```
+4. **Removed `cicada-core`** from workspace and publish workflow
 
-2. **Publishes cicada-core**
-   ```yaml
-   - name: Publish cicada-core to PyPI
-     run: |
-       cd packages/cicada-core
-       uv publish --token $UV_PUBLISH_TOKEN || echo "cicada-core version may already exist"
-   ```
-
-3. **Waits for availability** (30 seconds for PyPI propagation)
-
-4. **Then builds and publishes cicada-mcp** (which can now resolve cicada-core from PyPI)
-
-### Package Structure (unchanged)
+### New Package Structure
 
 ```
-packages/
-└── cicada-core/
-    ├── pyproject.toml
-    └── src/cicada_core/
-        ├── __init__.py
-        ├── base_indexer.py          # BaseIndexer ABC
-        ├── formatter_interface.py   # BaseLanguageFormatter ABC
-        └── utils/
-            ├── __init__.py
-            ├── hash_utils.py        # File hashing utilities
-            └── storage.py           # Storage path utilities
+cicada/
+├── core/
+│   ├── __init__.py          # Exports all shared utilities
+│   ├── base_indexer.py      # BaseIndexer ABC
+│   ├── hash_utils.py        # File hashing utilities
+│   └── storage.py           # Storage path utilities
+└── languages/
+    └── formatter_interface.py  # BaseLanguageFormatter (canonical source)
 ```
 
 ## Files Changed
 
-- `.github/workflows/publish-pypi.yml` - Added cicada-core build and publish steps to all jobs
-
-## Related
-
-- PR #225 (temporary fix by inlining BaseLanguageFormatter) - can be closed
-- `codebook/tasks/202512262109-MONOREPO_SPLIT.md` - Original monorepo split design
+- `cicada/core/` - New module with consolidated shared code
+- `cicada/languages/formatter_interface.py` - Updated comment
+- `packages/cicada-scip/pyproject.toml` - Depends on cicada-mcp instead of cicada-core
+- `packages/cicada-scip/src/cicada_scip/indexer.py` - Import from cicada.core
+- `packages/cicada-scip/src/cicada_scip/formatter.py` - Import from cicada.core
+- `pyproject.toml` - Removed cicada-core from workspace
+- `.github/workflows/publish-pypi.yml` - Removed cicada-core publishing
 
 ## Verification
 
-After the next release tag (e.g., `v0.6.1`), verify:
+After the next release:
 
 ```bash
-# cicada-mcp works standalone (BaseLanguageFormatter is inlined)
+# cicada-mcp works standalone
 pip install cicada-mcp
-python -c "from cicada.languages.formatter_interface import BaseLanguageFormatter; print('OK')"
+python -c "from cicada.core import BaseIndexer, BaseLanguageFormatter; print('OK')"
 
-# cicada-core is available on PyPI for cicada-scip users
-pip install cicada-core
-python -c "from cicada_core import BaseLanguageFormatter; print('OK')"
-
-# cicada-scip can be installed (depends on cicada-core from PyPI)
+# cicada-scip can be installed (now depends on cicada-mcp)
 pip install cicada-mcp[scip]
 ```

--- a/packages/cicada-scip/pyproject.toml
+++ b/packages/cicada-scip/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "cicada-core>=0.1.0",
+    "cicada-mcp>=0.6.0",
     "protobuf>=4.0.0",
 ]
 

--- a/packages/cicada-scip/src/cicada_scip/formatter.py
+++ b/packages/cicada-scip/src/cicada_scip/formatter.py
@@ -6,7 +6,7 @@ common formatting conventions. Both Python and TypeScript use () notation
 for function identifiers, regardless of arity.
 """
 
-from cicada_core import BaseLanguageFormatter
+from cicada.core import BaseLanguageFormatter
 
 
 class SCIPFormatter(BaseLanguageFormatter):

--- a/packages/cicada-scip/src/cicada_scip/indexer.py
+++ b/packages/cicada-scip/src/cicada_scip/indexer.py
@@ -14,14 +14,14 @@ import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from cicada_core import BaseIndexer
-from cicada_core.utils.hash_utils import (
+from cicada.core import (
+    BaseIndexer,
     compute_hashes_for_files,
     detect_file_changes,
+    get_hashes_path,
     load_file_hashes,
     save_file_hashes,
 )
-from cicada_core.utils.storage import get_hashes_path
 
 from cicada_scip.converter import SCIPConverter
 from cicada_scip.reader import SCIPReader

--- a/packages/cicada-scip/tests/test_typescript_formatter.py
+++ b/packages/cicada-scip/tests/test_typescript_formatter.py
@@ -9,7 +9,7 @@ conventions (parentheses notation, not Elixir's /arity notation).
 
 import pytest
 
-from cicada_core import BaseLanguageFormatter
+from cicada.core import BaseLanguageFormatter
 from cicada_scip.reader import SCIPReader
 from cicada_scip.converter import SCIPConverter
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 # Workspace configuration for monorepo
 [tool.uv.workspace]
-members = ["packages/cicada-core", "packages/cicada-scip"]
+members = ["packages/cicada-scip"]
 
 [tool.uv.sources]
-cicada-core = { workspace = true }
+cicada-mcp = { workspace = true }
 cicada-scip = { workspace = true }
 cicada-vector = { git = "https://github.com/wende/cicada-vector" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,6 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "cicada-core",
     "cicada-mcp",
     "cicada-scip",
 ]
@@ -289,26 +288,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cicada-core"
-version = "0.1.0"
-source = { editable = "packages/cicada-core" }
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-]
-yaml = [
-    { name = "pyyaml" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
-]
-provides-extras = ["yaml", "dev"]
-
-[[package]]
 name = "cicada-mcp"
 version = "0.6.0"
 source = { editable = "." }
@@ -411,7 +390,7 @@ name = "cicada-scip"
 version = "0.1.0"
 source = { editable = "packages/cicada-scip" }
 dependencies = [
-    { name = "cicada-core" },
+    { name = "cicada-mcp" },
     { name = "protobuf" },
 ]
 
@@ -422,7 +401,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cicada-core", editable = "packages/cicada-core" },
+    { name = "cicada-mcp", editable = "." },
     { name = "protobuf", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]


### PR DESCRIPTION
## Summary

The `cicada-core` package name is already taken on PyPI by another project (a CI/CD tool). Instead of renaming, this PR consolidates all shared code into `cicada-mcp` directly.

## Changes

- Create `cicada/core/` module with:
  - `BaseIndexer` - Abstract base class for language indexers
  - `BaseLanguageFormatter` - Re-exported from formatter_interface
  - `hash_utils` - File hashing for incremental indexing
  - `storage` - Storage path utilities
- Update `cicada-scip` to import from `cicada.core` instead of `cicada_core`
- Update `cicada-scip` dependency from `cicada-core>=0.1.0` to `cicada-mcp>=0.6.0`
- Remove `cicada-core` from workspace and publish workflow

## Benefits

- No need to publish a separate package
- Avoids PyPI name conflict
- Simpler dependency tree
- All shared code accessible via `from cicada.core import ...`

## Test plan

- [x] All 3307 tests pass
- [x] Pre-commit checks pass
- [ ] Verify PyPI installation works after release

Supersedes PR #228