### PR TITLE
Add Mistral Vibe editor support

### DIFF
--- a/cicada/clean.py
+++ b/cicada/clean.py
@@ -72,6 +72,51 @@ def remove_mcp_config_entry(config_path: Path, server_key: str = "cicada") -> bo
     return False
 
 
+def remove_vibe_mcp_entry(config_path: Path, server_name: str = "cicada") -> bool:
+    """
+    Remove Cicada entry from a Vibe TOML configuration file.
+
+    Args:
+        config_path: Path to the Vibe config.toml file
+        server_name: Server name to remove (default: "cicada")
+
+    Returns:
+        True if entry was removed, False if file doesn't exist or no entry found
+    """
+    import re
+
+    if not config_path.exists():
+        return False
+
+    try:
+        content = config_path.read_text()
+
+        # Pattern to match the cicada [[mcp_servers]] block
+        pattern = re.compile(
+            r"\[\[mcp_servers\]\]\s*\n"
+            r'name\s*=\s*"' + re.escape(server_name) + r'"\s*\n'
+            r"(?:(?!\[\[).)*",
+            re.DOTALL,
+        )
+
+        if not pattern.search(content):
+            return False
+
+        # Remove the block and any trailing blank lines
+        new_content = pattern.sub("", content)
+        # Clean up multiple consecutive blank lines
+        new_content = re.sub(r"\n{3,}", "\n\n", new_content).strip()
+        if new_content:
+            new_content += "\n"
+
+        config_path.write_text(new_content)
+        return True
+
+    except OSError as e:
+        print(f"Warning: Could not process {config_path}: {e}")
+        return False
+
+
 def clean_index_only(repo_path: Path) -> None:
     """
     Remove only the main index files (index.json, hashes.json, and embeddings.jsonl).
@@ -227,7 +272,7 @@ def clean_repository(repo_path: Path, force: bool = False) -> None:
     if old_cicada_dir.exists():
         items_to_remove.append(CleanItem("Legacy .cicada directory", old_cicada_dir))
 
-    # 3. MCP config files
+    # 3. MCP config files (JSON-based)
     mcp_configs = [
         (repo_path / ".mcp.json", "Claude Code config"),
         (repo_path / ".cursor" / "mcp.json", "Cursor config"),
@@ -247,6 +292,18 @@ def clean_repository(repo_path: Path, force: bool = False) -> None:
                     items_to_remove.append(CleanItem(desc, config_path, is_mcp_config=True))
             except (OSError, json.JSONDecodeError):
                 pass
+
+    # 3b. Vibe TOML config
+    vibe_config_path = repo_path / ".vibe" / "config.toml"
+    if vibe_config_path.exists():
+        try:
+            content = vibe_config_path.read_text()
+            if "cicada" in content.lower():
+                items_to_remove.append(
+                    CleanItem("Mistral Vibe config", vibe_config_path, is_mcp_config=True)
+                )
+        except OSError:
+            pass
 
     # Show what will be removed
     if not items_to_remove:
@@ -279,7 +336,12 @@ def clean_repository(repo_path: Path, force: bool = False) -> None:
     errors = []
     for item in items_to_remove:
         if item.is_mcp_config:
-            if remove_mcp_config_entry(item.path):
+            # Use TOML-based removal for Vibe, JSON-based for others
+            if str(item.path).endswith(".toml"):
+                success = remove_vibe_mcp_entry(item.path)
+            else:
+                success = remove_mcp_config_entry(item.path)
+            if success:
                 print(f"✓ Removed 'cicada' entry from {item.description}")
                 removed_count += 1
             else:

--- a/cicada/commands.py
+++ b/cicada/commands.py
@@ -32,6 +32,7 @@ KNOWN_SUBCOMMANDS: tuple[str, ...] = (
     "gemini",
     "codex",
     "zed",
+    "vibe",
     "watch",
     "index",
     "index-pr",
@@ -149,6 +150,11 @@ def _add_editor_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Skip editor selection, use Zed",
     )
+    parser.add_argument(
+        "--vibe",
+        action="store_true",
+        help="Skip editor selection, use Mistral Vibe",
+    )
 
 
 def _create_editor_subparser(
@@ -162,6 +168,7 @@ def _create_editor_subparser(
         "gemini": "Gemini CLI",
         "codex": "Codex",
         "zed": "Zed",
+        "vibe": "Mistral Vibe",
     }
     display_name = editor_display_names.get(name, name.title())
     parser = subparsers.add_parser(
@@ -265,7 +272,7 @@ def get_argument_parser():
     )
 
     # Editor-specific subparsers (all have identical structure with mode args)
-    for editor in ["claude", "cursor", "vs", "gemini", "codex", "zed"]:
+    for editor in ["claude", "cursor", "vs", "gemini", "codex", "zed", "vibe"]:
         _create_editor_subparser(subparsers, editor, common_parser)
 
     watch_parser = subparsers.add_parser(
@@ -678,6 +685,7 @@ def handle_command(args) -> bool:
         "gemini": lambda args: handle_editor_setup(args, "gemini"),
         "codex": lambda args: handle_editor_setup(args, "codex"),
         "zed": lambda args: handle_editor_setup(args, "zed"),
+        "vibe": lambda args: handle_editor_setup(args, "vibe"),
         "watch": handle_watch,
         "index": handle_index,
         "index-pr": handle_index_pr,
@@ -1474,7 +1482,7 @@ def _determine_editor_from_args(args) -> str | None:
     Raises:
         SystemExit: If multiple editor flags specified
     """
-    editor_flags = [args.claude, args.cursor, args.vs, args.gemini, args.codex, args.zed]
+    editor_flags = [args.claude, args.cursor, args.vs, args.gemini, args.codex, args.zed, args.vibe]
     editor_count = sum(editor_flags)
 
     if editor_count > 1:
@@ -1493,6 +1501,8 @@ def _determine_editor_from_args(args) -> str | None:
         return "codex"
     if args.zed:
         return "zed"
+    if args.vibe:
+        return "vibe"
     return None
 
 
@@ -1516,6 +1526,7 @@ def _prompt_for_editor() -> str:
         "Gemini CLI (Google Gemini command line interface)",
         "Codex (AI code editor)",
         "Zed (High-performance code editor)",
+        "Mistral Vibe (Mistral AI coding assistant)",
     ]
     editor_menu = TerminalMenu(editor_options, title="Choose your editor:")
     menu_idx = editor_menu.show()
@@ -1526,13 +1537,14 @@ def _prompt_for_editor() -> str:
 
     # Map menu index to editor type
     assert isinstance(menu_idx, int), "menu_idx must be an integer"
-    editor_map: tuple[str, str, str, str, str, str] = (
+    editor_map: tuple[str, str, str, str, str, str, str] = (
         "claude",
         "cursor",
         "vs",
         "gemini",
         "codex",
         "zed",
+        "vibe",
     )
     return editor_map[menu_idx]
 
@@ -1649,6 +1661,8 @@ def _configure_editors_if_requested(args, repo_path: Path, storage_dir: Path) ->
         editors_to_configure.append("codex")
     if args.zed:
         editors_to_configure.append("zed")
+    if args.vibe:
+        editors_to_configure.append("vibe")
 
     if editors_to_configure:
         try:

--- a/cicada/interactive_setup.py
+++ b/cicada/interactive_setup.py
@@ -553,14 +553,15 @@ def _text_based_editor_selection() -> str:
     print("4. Gemini CLI - Google Gemini command line interface")
     print("5. Codex - AI code editor")
     print("6. OpenCode - Terminal-based AI coding agent")
+    print("7. Mistral Vibe - Mistral AI coding assistant")
     print()
 
     while True:
         try:
-            choice = input("Enter your choice (1-6) [default: 1]: ").strip()
+            choice = input("Enter your choice (1-7) [default: 1]: ").strip()
             if not choice:
                 choice = "1"
-            if choice in ("1", "2", "3", "4", "5", "6"):
+            if choice in ("1", "2", "3", "4", "5", "6", "7"):
                 editor_map = {
                     "1": "claude",
                     "2": "cursor",
@@ -568,9 +569,10 @@ def _text_based_editor_selection() -> str:
                     "4": "gemini",
                     "5": "codex",
                     "6": "opencode",
+                    "7": "vibe",
                 }
                 return editor_map[choice]
-            print("Invalid choice. Please enter 1-6.")
+            print("Invalid choice. Please enter 1-7.")
         except (KeyboardInterrupt, EOFError):
             print()
             print("Setup cancelled. Exiting...")
@@ -665,6 +667,7 @@ def show_full_interactive_setup(repo_path: str | Path | None = None) -> None:
                     3: "gemini",
                     4: "codex",
                     5: "opencode",
+                    6: "vibe",
                 }
                 editor = editor_map[
                     int(editor_index) if isinstance(editor_index, int) else editor_index[0]

--- a/cicada/interactive_setup_helpers.py
+++ b/cicada/interactive_setup_helpers.py
@@ -35,6 +35,7 @@ _EDITOR_OPTIONS = (
     ("Gemini CLI", "gemini"),
     ("Codex", "codex"),
     ("OpenCode", "opencode"),
+    ("Mistral Vibe", "vibe"),
 )
 
 EDITOR_ITEMS = [label for label, _ in _EDITOR_OPTIONS]

--- a/cicada/setup.py
+++ b/cicada/setup.py
@@ -23,7 +23,7 @@ from cicada.utils import (
     get_index_path,
 )
 
-EditorType = Literal["claude", "cursor", "vs", "gemini", "codex", "opencode", "zed"]
+EditorType = Literal["claude", "cursor", "vs", "gemini", "codex", "opencode", "zed", "vibe"]
 
 
 def detect_project_language(repo_path: Path) -> str:
@@ -320,6 +320,105 @@ def get_mcp_config_for_editor(
     return config_path, config
 
 
+def _generate_vibe_toml_section(storage_dir: Path) -> str:
+    """
+    Generate the [[mcp_servers]] TOML block for Vibe.
+
+    Args:
+        storage_dir: Path to the storage directory
+
+    Returns:
+        TOML section string for the cicada MCP server
+    """
+    return (
+        "[[mcp_servers]]\n"
+        'name = "cicada"\n'
+        'transport = "stdio"\n'
+        'command = "uvx"\n'
+        'args = ["cicada-mcp"]\n'
+        f'env = {{ "CICADA_CONFIG_DIR" = "{storage_dir}" }}\n'
+    )
+
+
+def _update_vibe_config_content(existing: str, new_section: str) -> str:
+    """
+    Merge a new cicada TOML section into existing Vibe config content.
+
+    If a cicada section already exists, replace it. Otherwise, append it.
+
+    Args:
+        existing: Existing TOML config content
+        new_section: New cicada TOML section to insert
+
+    Returns:
+        Updated TOML content
+    """
+    import re
+
+    # Pattern to match existing cicada [[mcp_servers]] block
+    # Matches from [[mcp_servers]] with name = "cicada" to the next [[section]] or end of file
+    pattern = re.compile(
+        r'\[\[mcp_servers\]\]\s*\nname\s*=\s*"cicada"\s*\n(?:(?!\[\[).)*',
+        re.DOTALL,
+    )
+
+    if pattern.search(existing):
+        return pattern.sub(new_section, existing)
+
+    # Append new section
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    if existing:
+        existing += "\n"
+    return existing + new_section
+
+
+def get_vibe_config(repo_path: Path, storage_dir: Path) -> tuple[Path, str]:
+    """
+    Get the Vibe MCP configuration file path and TOML content.
+
+    Args:
+        repo_path: Path to the repository
+        storage_dir: Path to the storage directory
+
+    Returns:
+        Tuple of (config_file_path, toml_content_string)
+    """
+    config_path = repo_path / ".vibe" / "config.toml"
+    config_path.parent.mkdir(exist_ok=True)
+
+    new_section = _generate_vibe_toml_section(storage_dir)
+
+    # Load existing config if present
+    existing = ""
+    if config_path.exists():
+        try:
+            existing = config_path.read_text()
+        except OSError:
+            existing = ""
+
+    content = _update_vibe_config_content(existing, new_section)
+    return config_path, content
+
+
+def write_editor_config(editor: EditorType, config_path: Path, content: str | dict) -> None:
+    """
+    Write editor config file. Uses JSON for most editors, plain text for TOML-based editors.
+
+    Args:
+        editor: Editor type
+        config_path: Path to the config file
+        content: Config content (dict for JSON editors, str for TOML editors)
+    """
+    if editor == "vibe":
+        assert isinstance(content, str), "Vibe config content must be a string"
+        with open(config_path, "w") as f:
+            f.write(content)
+    else:
+        with open(config_path, "w") as f:
+            json.dump(content, f, indent=2)
+
+
 def create_config_yaml(
     repo_path: Path,
     storage_dir: Path,
@@ -447,11 +546,15 @@ def setup_multiple_editors(
     """
     for editor in editors:
         try:
-            config_path, config_content = get_mcp_config_for_editor(editor, repo_path, storage_dir)
+            if editor == "vibe":
+                config_path, config_content = get_vibe_config(repo_path, storage_dir)
+            else:
+                config_path, config_content = get_mcp_config_for_editor(
+                    editor, repo_path, storage_dir
+                )
 
             # Write config file
-            with open(config_path, "w") as f:
-                json.dump(config_content, f, indent=2)
+            write_editor_config(editor, config_path, config_content)
 
             if verbose:
                 print(f"✓ Created {editor.upper()} config at {config_path}")
@@ -729,14 +832,16 @@ def setup(
     _setup_gitattributes(repo_path)
 
     # Create MCP config for the editor
-    config_path, config_content = get_mcp_config_for_editor(editor, repo_path, storage_dir)
+    if editor == "vibe":
+        config_path, config_content = get_vibe_config(repo_path, storage_dir)
+    else:
+        config_path, config_content = get_mcp_config_for_editor(editor, repo_path, storage_dir)
 
     # Check if MCP config already exists
     mcp_config_existed = config_path.exists()
 
     # Write config file
-    with open(config_path, "w") as f:
-        json.dump(config_content, f, indent=2)
+    write_editor_config(editor, config_path, config_content)
 
     if index_exists:
         # Show condensed success message

--- a/cicada/status.py
+++ b/cicada/status.py
@@ -212,6 +212,11 @@ def find_mcp_files(repo_path: Path) -> dict:
             "description": "OpenCode config",
             "editor": "OpenCode",
         },
+        {
+            "path": repo_path / ".vibe" / "config.toml",
+            "description": "Mistral Vibe config",
+            "editor": "Mistral Vibe",
+        },
     ]
 
     existing_files = []

--- a/tests/cli/test_install_flags.py
+++ b/tests/cli/test_install_flags.py
@@ -43,6 +43,7 @@ def test_install_yes_flag(mock_setup, mock_detect_language, mock_mode_flags, moc
     args.gemini = False
     args.codex = False
     args.zed = False
+    args.vibe = False
     args.index_prs = False
     args.no_index_prs = False
     args.skip_optional = False
@@ -72,6 +73,7 @@ def test_install_index_prs_flag(
     args.gemini = False
     args.codex = False
     args.zed = False
+    args.vibe = False
     args.index_prs = True
     args.no_index_prs = False
     args.skip_optional = False
@@ -96,6 +98,7 @@ def test_install_skip_optional_flag(
     args.gemini = False
     args.codex = False
     args.zed = False
+    args.vibe = False
     args.index_prs = False
     args.no_index_prs = False
     args.skip_optional = True

--- a/tests/fixtures/.cicada/hashes.json
+++ b/tests/fixtures/.cicada/hashes.json
@@ -14,5 +14,5 @@
     "test_with_docs.ex": "4118705f9325a3184366a3d698111334",
     "test_with_tests.exs": "9409efccd0c5e7d8f88e6f68b0b60c3f"
   },
-  "last_updated": "2026-02-17T23:31:45.365601Z"
+  "last_updated": "2026-02-23T14:46:28.351707Z"
 }

--- a/tests/setup/test_clean.py
+++ b/tests/setup/test_clean.py
@@ -14,6 +14,7 @@ from cicada.clean import (
     clean_repository,
     main,
     remove_mcp_config_entry,
+    remove_vibe_mcp_entry,
 )
 
 
@@ -801,3 +802,113 @@ class TestCleanAllProjects:
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "1/2 projects removed" in captured.out
+
+
+class TestRemoveVibeMcpEntry:
+    """Tests for remove_vibe_mcp_entry function"""
+
+    def test_removes_cicada_entry_from_vibe_config(self, tmp_path):
+        """Should remove cicada entry from Vibe TOML config"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[[mcp_servers]]\n"
+            'name = "cicada"\n'
+            'transport = "stdio"\n'
+            'command = "uvx"\n'
+            'args = ["cicada-mcp"]\n'
+            'env = { "CICADA_CONFIG_DIR" = "/tmp/test" }\n'
+            "\n"
+            "[[mcp_servers]]\n"
+            'name = "other"\n'
+            'command = "other-cmd"\n'
+        )
+
+        result = remove_vibe_mcp_entry(config_path)
+        assert result is True
+
+        content = config_path.read_text()
+        assert "cicada" not in content
+        assert 'name = "other"' in content
+
+    def test_returns_false_when_file_not_exists(self, tmp_path):
+        """Should return False when config file doesn't exist"""
+        non_existent = tmp_path / "config.toml"
+        result = remove_vibe_mcp_entry(non_existent)
+        assert result is False
+
+    def test_returns_false_when_no_cicada_entry(self, tmp_path):
+        """Should return False when no cicada entry exists"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[[mcp_servers]]\n" 'name = "other"\n' 'command = "other-cmd"\n')
+
+        result = remove_vibe_mcp_entry(config_path)
+        assert result is False
+
+    def test_removes_only_cicada_entry(self, tmp_path):
+        """Should remove only the cicada entry and keep others"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[[mcp_servers]]\n"
+            'name = "first"\n'
+            'command = "first-cmd"\n'
+            "\n"
+            "[[mcp_servers]]\n"
+            'name = "cicada"\n'
+            'transport = "stdio"\n'
+            'command = "uvx"\n'
+            "\n"
+            "[[mcp_servers]]\n"
+            'name = "last"\n'
+            'command = "last-cmd"\n'
+        )
+
+        result = remove_vibe_mcp_entry(config_path)
+        assert result is True
+
+        content = config_path.read_text()
+        assert 'name = "first"' in content
+        assert 'name = "last"' in content
+        assert 'name = "cicada"' not in content
+
+    def test_handles_cicada_only_config(self, tmp_path):
+        """Should handle config with only cicada entry"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[[mcp_servers]]\n" 'name = "cicada"\n' 'transport = "stdio"\n' 'command = "uvx"\n'
+        )
+
+        result = remove_vibe_mcp_entry(config_path)
+        assert result is True
+
+        content = config_path.read_text()
+        assert "cicada" not in content
+
+
+class TestCleanRepositoryWithVibe:
+    """Tests for clean_repository with Vibe config"""
+
+    def test_removes_vibe_config_entry(self, tmp_path):
+        """Should remove cicada entry from Vibe config during clean"""
+        repo_path = tmp_path / "test_repo"
+        repo_path.mkdir()
+
+        # Create Vibe config with cicada entry
+        vibe_dir = repo_path / ".vibe"
+        vibe_dir.mkdir()
+        vibe_config = vibe_dir / "config.toml"
+        vibe_config.write_text(
+            "[[mcp_servers]]\n"
+            'name = "cicada"\n'
+            'transport = "stdio"\n'
+            'command = "uvx"\n'
+            'args = ["cicada-mcp"]\n'
+        )
+
+        storage_dir = tmp_path / ".cicada" / "projects" / "test_hash"
+
+        with patch("cicada.clean.get_storage_dir", return_value=storage_dir):
+            clean_repository(repo_path, force=True)
+
+        # Vibe config should have cicada removed
+        content = vibe_config.read_text()
+        assert "cicada" not in content

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -16,10 +16,14 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from cicada.setup import (
+    _generate_vibe_toml_section,
+    _update_vibe_config_content,
     create_config_yaml,
     get_mcp_config_for_editor,
+    get_vibe_config,
     index_repository,
     setup,
+    write_editor_config,
 )
 
 
@@ -415,9 +419,9 @@ class TestSetupFunction:
 
     def test_setup_all_editors(self, mock_repo):
         """Setup should work for all editor types"""
-        editors = ["claude", "cursor", "vs", "gemini", "codex", "zed"]
+        json_editors = ["claude", "cursor", "vs", "gemini", "codex", "zed"]
 
-        for editor in editors:
+        for editor in json_editors:
             with patch("cicada.setup.create_storage_dir"):
                 with patch("cicada.setup.index_repository"):
                     with patch("cicada.setup.create_config_yaml"):
@@ -427,6 +431,18 @@ class TestSetupFunction:
 
                             # Should not raise an error
                             setup(editor, mock_repo)
+
+        # Test Vibe separately (uses TOML, not JSON)
+        with patch("cicada.setup.create_storage_dir"):
+            with patch("cicada.setup.index_repository"):
+                with patch("cicada.setup.create_config_yaml"):
+                    with patch("cicada.setup.get_vibe_config") as mock_vibe:
+                        vibe_dir = mock_repo / ".vibe"
+                        vibe_dir.mkdir(exist_ok=True)
+                        config_path = vibe_dir / "config.toml"
+                        mock_vibe.return_value = (config_path, "[[mcp_servers]]\n")
+
+                        setup("vibe", mock_repo)
 
 
 # ============================================================================
@@ -556,3 +572,127 @@ class TestSetupIndexExists:
 
                         captured = capsys.readouterr()
                         assert "✓ Found existing index" in captured.out
+
+
+# ============================================================================
+# Vibe (TOML) Config Tests
+# ============================================================================
+
+
+class TestVibeConfig:
+    """Tests for Vibe TOML config generation and merging"""
+
+    @pytest.fixture
+    def mock_repo(self, tmp_path):
+        """Create a mock repository"""
+        repo_path = tmp_path / "test_repo"
+        repo_path.mkdir()
+        return repo_path
+
+    @pytest.fixture
+    def mock_storage_dir(self, tmp_path):
+        """Create a mock storage directory"""
+        storage_dir = tmp_path / "storage"
+        storage_dir.mkdir()
+        return storage_dir
+
+    def test_generate_vibe_toml_section(self, mock_storage_dir):
+        """Should generate valid TOML section"""
+        section = _generate_vibe_toml_section(mock_storage_dir)
+
+        assert "[[mcp_servers]]" in section
+        assert 'name = "cicada"' in section
+        assert 'transport = "stdio"' in section
+        assert 'command = "uvx"' in section
+        assert 'args = ["cicada-mcp"]' in section
+        assert f'"CICADA_CONFIG_DIR" = "{mock_storage_dir}"' in section
+
+    def test_get_vibe_config_creates_directory(self, mock_repo, mock_storage_dir):
+        """Should create .vibe directory"""
+        config_path, content = get_vibe_config(mock_repo, mock_storage_dir)
+
+        assert config_path == mock_repo / ".vibe" / "config.toml"
+        assert config_path.parent.exists()
+        assert "[[mcp_servers]]" in content
+        assert 'name = "cicada"' in content
+
+    def test_get_vibe_config_preserves_existing(self, mock_repo, mock_storage_dir):
+        """Should preserve existing non-cicada content"""
+        vibe_dir = mock_repo / ".vibe"
+        vibe_dir.mkdir()
+        existing = (
+            "[[mcp_servers]]\n"
+            'name = "other-server"\n'
+            'transport = "stdio"\n'
+            'command = "other"\n'
+            "\n"
+        )
+        (vibe_dir / "config.toml").write_text(existing)
+
+        config_path, content = get_vibe_config(mock_repo, mock_storage_dir)
+
+        # Should keep existing server
+        assert 'name = "other-server"' in content
+        # Should add cicada server
+        assert 'name = "cicada"' in content
+
+    def test_update_vibe_config_replaces_existing_cicada(self, mock_storage_dir):
+        """Should replace existing cicada block"""
+        existing = (
+            "[[mcp_servers]]\n"
+            'name = "cicada"\n'
+            'transport = "stdio"\n'
+            'command = "old-command"\n'
+            'args = ["old-arg"]\n'
+            "\n"
+            "[[mcp_servers]]\n"
+            'name = "other"\n'
+            'command = "other"\n'
+        )
+        new_section = _generate_vibe_toml_section(mock_storage_dir)
+
+        result = _update_vibe_config_content(existing, new_section)
+
+        # Should have replaced the cicada block
+        assert 'command = "old-command"' not in result
+        assert 'command = "uvx"' in result
+        # Should keep the other block
+        assert 'name = "other"' in result
+
+    def test_update_vibe_config_appends_when_no_cicada(self, mock_storage_dir):
+        """Should append cicada block when none exists"""
+        existing = "[[mcp_servers]]\n" 'name = "other"\n' 'command = "other"\n'
+        new_section = _generate_vibe_toml_section(mock_storage_dir)
+
+        result = _update_vibe_config_content(existing, new_section)
+
+        assert 'name = "other"' in result
+        assert 'name = "cicada"' in result
+
+    def test_update_vibe_config_empty_existing(self, mock_storage_dir):
+        """Should handle empty existing content"""
+        new_section = _generate_vibe_toml_section(mock_storage_dir)
+
+        result = _update_vibe_config_content("", new_section)
+
+        assert 'name = "cicada"' in result
+        assert result == new_section
+
+    def test_write_editor_config_vibe(self, tmp_path):
+        """write_editor_config should write plain text for Vibe"""
+        config_path = tmp_path / "config.toml"
+        content = '[[mcp_servers]]\nname = "cicada"\n'
+
+        write_editor_config("vibe", config_path, content)
+
+        assert config_path.read_text() == content
+
+    def test_write_editor_config_json(self, tmp_path):
+        """write_editor_config should write JSON for other editors"""
+        config_path = tmp_path / "config.json"
+        content = {"mcpServers": {"cicada": {"command": "uvx"}}}
+
+        write_editor_config("claude", config_path, content)
+
+        written = json.loads(config_path.read_text())
+        assert written == content


### PR DESCRIPTION
## Summary

- Add `"vibe"` as a new editor type with `--vibe` CLI flag and `cicada vibe` subcommand
- Generate TOML-based `.vibe/config.toml` with `[[mcp_servers]]` blocks (unlike JSON for other editors)
- Handle config merging: replace existing cicada section or append to preserve other MCP servers
- Add TOML-aware clean/uninstall via `remove_vibe_mcp_entry()`
- Add Vibe to interactive setup menus (TUI and text-based), status detection, and multi-editor install

## Test plan

- [x] All 3694 tests pass
- [x] TOML generation produces valid `[[mcp_servers]]` block
- [x] Config merging replaces existing cicada section correctly
- [x] Config merging appends when no cicada section exists
- [x] Existing non-cicada servers are preserved during merge
- [x] Clean removes cicada entry from TOML without affecting other servers
- [x] `write_editor_config` routes vibe to plain text, others to JSON
- [x] Pre-commit hooks pass (black, ruff, pyrefly, vulture)