### PR TITLE
Fix stale index reference in module and function search handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale index reference in module and function search handlers**
+  - `ModuleSearchHandler` and `FunctionSearchHandler` now read the index through the `IndexManager` on each call, so reloaded indexes are visible to `search_module`, `search_function`, and `expand_result` without a server restart
+  - `query` / `query_jq` (via `AnalysisHandler`) were already correct; this brings the other handlers in line
+  - Handler `__init__` accepts either an `IndexManager` (preferred) or a code index dict (legacy), so existing callers continue to work
+
 ## [0.6.5] - 2026-03-03
 
 ### Added

--- a/cicada/mcp/handlers/function_handlers.py
+++ b/cicada/mcp/handlers/function_handlers.py
@@ -6,12 +6,15 @@ Handles tools for searching functions and analyzing their call sites.
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from mcp.types import TextContent
 
 from cicada.mcp.filter_utils import filter_by_file_type
 from cicada.mcp.pattern_utils import FunctionPattern, parse_function_patterns
+
+if TYPE_CHECKING:
+    from cicada.mcp.handlers.index_manager import IndexManager
 
 
 class FunctionSearchHandler:
@@ -26,18 +29,29 @@ class FunctionSearchHandler:
 
     def __init__(
         self,
-        index: dict[str, Any],
+        index: "IndexManager | dict[str, Any]",
         config: dict[str, Any],
     ):
         """
         Initialize the function search handler.
 
         Args:
-            index: The code index containing modules and functions
+            index: An ``IndexManager`` (preferred) or a code index dict.
+                Passing the manager lets the handler observe reloads.
             config: Configuration dictionary
         """
-        self.index = index
+        self._index_source = index
         self.config = config
+
+    @property
+    def index(self) -> dict[str, Any]:
+        """Return the current code index, read through the source on each access."""
+        source = self._index_source
+        return source.index if hasattr(source, "index") else source
+
+    @index.setter
+    def index(self, value: "IndexManager | dict[str, Any]") -> None:
+        self._index_source = value
 
     def _extract_dependency_contexts(
         self, dependencies: list[dict[str, Any]], file_path: str

--- a/cicada/mcp/handlers/module_handlers.py
+++ b/cicada/mcp/handlers/module_handlers.py
@@ -5,13 +5,16 @@ Handles tools for searching modules and analyzing module usage.
 """
 
 import json
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from mcp.types import TextContent
 
 from cicada.format import ModuleFormatter
 from cicada.mcp.pattern_utils import has_wildcards, match_any_pattern, split_or_patterns
 from cicada.utils import find_similar_names
+
+if TYPE_CHECKING:
+    from cicada.mcp.handlers.index_manager import IndexManager
 
 
 class ModuleSearchHandler:
@@ -25,18 +28,29 @@ class ModuleSearchHandler:
 
     def __init__(
         self,
-        index: dict[str, Any],
+        index: "IndexManager | dict[str, Any]",
         config: dict[str, Any],
     ):
         """
         Initialize the module search handler.
 
         Args:
-            index: The code index containing modules and functions
+            index: An ``IndexManager`` (preferred) or a code index dict.
+                Passing the manager lets the handler observe reloads.
             config: Configuration dictionary
         """
-        self.index = index
+        self._index_source = index
         self.config = config
+
+    @property
+    def index(self) -> dict[str, Any]:
+        """Return the current code index, read through the source on each access."""
+        source = self._index_source
+        return source.index if hasattr(source, "index") else source
+
+    @index.setter
+    def index(self, value: "IndexManager | dict[str, Any]") -> None:
+        self._index_source = value
 
     def _get_function_bounds(
         self, module_name: str, function_name: str, arity: int

--- a/cicada/mcp/router.py
+++ b/cicada/mcp/router.py
@@ -671,8 +671,8 @@ def create_tool_router(config: dict) -> tuple[ToolRouter, IndexManager, GitHelpe
         print(f"Warning: Git helper not available: {e}", file=sys.stderr)
 
     # Initialize handlers
-    module_handler = ModuleSearchHandler(index_manager.index, config)
-    function_handler = FunctionSearchHandler(index_manager.index, config)
+    module_handler = ModuleSearchHandler(index_manager, config)
+    function_handler = FunctionSearchHandler(index_manager, config)
     git_handler = GitHistoryHandler(git_helper, config)
     pr_handler = PRHistoryHandler(index_manager.pr_index, config)
     analysis_handler = AnalysisHandler(index_manager)

--- a/tests/mcp/test_index_manager.py
+++ b/tests/mcp/test_index_manager.py
@@ -562,6 +562,31 @@ class TestIndexManagerStalenessCheck:
         assert manager._pr_index is None  # Should be invalidated
         assert manager._has_keywords is False
 
+    def test_handlers_see_index_after_reload(self):
+        """Handlers initialized with IndexManager observe a reloaded index."""
+        from cicada.mcp.handlers.module_handlers import ModuleSearchHandler
+
+        original_index = {"modules": {"old": {}}}
+        new_index = {"modules": {"new": {}}}
+        config = {"storage": {"index_path": "/fake/path"}}
+
+        manager = IndexManager.__new__(IndexManager)
+        manager.config = config
+        manager._index = original_index
+        manager._index_mtime = 100.0
+        manager._pr_index = None
+        manager._has_keywords = False
+
+        handler = ModuleSearchHandler(manager, config)
+        assert handler.index["modules"] == {"old": {}}
+
+        with patch.object(manager, "_get_index_mtime", return_value=200.0):
+            with patch.object(manager, "_load_index", return_value=new_index):
+                with patch.object(manager, "_check_keywords_available", return_value=False):
+                    manager.reload_if_changed()
+
+        assert handler.index["modules"] == {"new": {}}
+
     def test_reload_if_changed_corrupted_index(self):
         """Test reload_if_changed handles corrupted index gracefully."""
         original_index = {"modules": {"original": {}}}


### PR DESCRIPTION
## Problem

After a successful index reload (either the background refresher or the
`refresh_index` MCP tool), `search_module`, `search_function`, and
`expand_result` continue to serve results from the index snapshot that
was loaded at server startup. `query` and `query_jq` correctly return
fresh results from the same reload.

This shows up as a split-brain: `query` finds a module that was added
since startup, but `search_module` reports it as missing — and the error
message even reports a different `total_modules` than the one
`query_jq .metadata` returns from the same reload.

Reproduction:

1. Start the MCP server against a project.
2. Add a new module to the project.
3. Run `refresh_index` (or wait for the background refresher).
4. `query("NewModule")` finds it; `search_module("NewModule")` does not.

## Cause

`router.py` initializes the handlers asymmetrically:

```python
module_handler   = ModuleSearchHandler(index_manager.index, config)
function_handler = FunctionSearchHandler(index_manager.index, config)
analysis_handler = AnalysisHandler(index_manager)
```

`ModuleSearchHandler` and `FunctionSearchHandler` capture
`index_manager.index` (the dict reference) at startup and store it as
`self.index`. `AnalysisHandler` stores `index_manager` itself and reads
`self.index_manager.index` per call.

`IndexManager.reload_if_changed` rebinds `self._index = new_index`, so
`AnalysisHandler` sees the new dict but the captured references in the
other two handlers keep pointing at the old one.

## Fix

Bring `ModuleSearchHandler` and `FunctionSearchHandler` in line with
`AnalysisHandler`: read the index through the source on each access
instead of capturing the dict reference at init.

- `__init__` accepts either an `IndexManager` (preferred) or a code
  index dict (legacy), stored as `self._index_source`.
- `self.index` becomes a `@property` returning `source.index` if the
  source is a manager, else the raw dict.
- A matching `@index.setter` preserves the existing
  `module_handler.index = {...}` test idiom in
  `tests/mcp/test_server_core.py::TestCompactModuleFormat`.
- `router.py` now passes `index_manager` to both handlers.
- `IndexManager.reload_if_changed` is unchanged — its atomic
  `self._index = new_index` rebind is preserved, avoiding any
  concurrent-iteration risk on the index dict.

The dual `IndexManager | dict[str, Any]` type uses the existing
`TYPE_CHECKING` pattern from `analysis_handlers.py`. Existing test
fixtures that pass a dict directly continue to work unchanged.

## Test

`test_handlers_see_index_after_reload` (in `TestIndexManagerStalenessCheck`):
constructs a `ModuleSearchHandler` against an `IndexManager`, asserts
the handler returns the original index, mutates the manager via
`reload_if_changed`, and asserts the handler now returns the new index.
This is the user-facing guarantee: a reload mid-session is observable
through the handler.

## Verification (CONTRIBUTING.md checklist)

- `black --check cicada tests` — 366 files unchanged.
- `pytest --cov=cicada` — `3520 passed, 226 skipped`. Remaining
  failures (`tests/integration/test_acceptance*`, SCIP-dependent
  tests under `tests/languages/`) reproduce on `main` in the same
  environment and are not introduced by this change.
- `CHANGELOG.md` updated under `## [Unreleased] / ### Fixed`.
