### PR TITLE
Add native Gleam indexing

### DIFF
--- a/cicada/commands.py
+++ b/cicada/commands.py
@@ -16,8 +16,6 @@ from cicada.index_mode import (
     mode_flag_specified,
     validate_mode_flags,
 )
-
-# Import indexing mode resolution functions from centralized module
 from cicada.languages.generic.indexer import run_generic_indexing_for_language_indexer
 
 # Default debounce interval for watch mode (in seconds)
@@ -918,11 +916,20 @@ def handle_index_main(args) -> None:
                 config_path=str(config_path),
             )
 
+        from cicada.setup import _merge_embedded_gleam_index
+
+        extra_excluded_extensions = _merge_embedded_gleam_index(
+            repo_path,
+            index_path,
+            language,
+            verbose=verbose,
+        )
         run_generic_indexing_for_language_indexer(
             indexer,
             repo_path,
             index_path,
             verbose=verbose,
+            extra_excluded_extensions=extra_excluded_extensions,
         )
 
         # If embeddings mode, generate embeddings after the regular index

--- a/cicada/languages/__init__.py
+++ b/cicada/languages/__init__.py
@@ -248,6 +248,15 @@ LanguageRegistry.register_language(
     formatter_class="cicada.languages.erlang.formatter.ErlangFormatter",
 )
 
+# Register Gleam (tree-sitter based - always available)
+LanguageRegistry.register_language(
+    language="gleam",
+    parser_class="cicada.languages.gleam.parser.GleamParser",
+    indexer_class="cicada.languages.gleam.indexer.GleamIndexer",
+    config=LanguageConfig.default_gleam(),
+    formatter_class="cicada.languages.gleam.formatter.GleamFormatter",
+)
+
 # SCIP-based languages
 # Register Python (SCIP-based)
 LanguageRegistry.register_language(

--- a/cicada/languages/generic/indexer.py
+++ b/cicada/languages/generic/indexer.py
@@ -259,6 +259,7 @@ def run_generic_indexing_for_language_indexer(
     repo_path: str | Path,
     index_path: str | Path,
     verbose: bool = False,
+    extra_excluded_extensions: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """
     Run generic indexing using the extensions reported by a primary language indexer.
@@ -266,7 +267,10 @@ def run_generic_indexing_for_language_indexer(
     return run_generic_indexing(
         repo_path=repo_path,
         index_path=index_path,
-        excluded_extensions=language_indexer.get_file_extensions(),
+        excluded_extensions=[
+            *language_indexer.get_file_extensions(),
+            *(extra_excluded_extensions or []),
+        ],
         verbose=verbose,
     )
 

--- a/cicada/languages/gleam/__init__.py
+++ b/cicada/languages/gleam/__init__.py
@@ -1,0 +1,7 @@
+"""Gleam language support for Cicada."""
+
+from cicada.languages.gleam.formatter import GleamFormatter
+from cicada.languages.gleam.indexer import GleamIndexer
+from cicada.languages.gleam.parser import GleamParser
+
+__all__ = ["GleamFormatter", "GleamIndexer", "GleamParser"]

--- a/cicada/languages/gleam/formatter.py
+++ b/cicada/languages/gleam/formatter.py
@@ -1,0 +1,19 @@
+"""Gleam-specific formatting utilities."""
+
+from cicada.languages.formatter_interface import BaseLanguageFormatter
+
+
+class GleamFormatter(BaseLanguageFormatter):
+    """Formatter for Gleam language conventions."""
+
+    def format_function_identifier(self, module_name: str, func_name: str, arity: int) -> str:
+        """Format a fully-qualified Gleam function identifier."""
+        return f"{module_name}.{func_name}/{arity}"
+
+    def format_function_name(
+        self, func_name: str, arity: int, args: list[str] | None = None
+    ) -> str:
+        """Format a Gleam function name with arguments when available."""
+        if args:
+            return f"{func_name}({', '.join(args)})"
+        return f"{func_name}/{arity}"

--- a/cicada/languages/gleam/indexer.py
+++ b/cicada/languages/gleam/indexer.py
@@ -1,0 +1,179 @@
+"""Gleam indexer implementation."""
+
+from pathlib import Path
+from typing import Any
+
+from cicada.languages.gleam.parser import GleamParser
+from cicada.parsing.base_indexer import BaseIndexer
+from cicada.parsing.language_config import LanguageConfig
+from cicada.utils import load_index, save_index
+from cicada.utils.keyword_utils import get_keyword_extractor_from_config
+
+
+class GleamIndexer(BaseIndexer):
+    """Indexer for Gleam projects."""
+
+    def __init__(self):
+        self.parser = GleamParser()
+        self.config = LanguageConfig.default_gleam()
+        self.keyword_extractor: Any = None
+
+    def get_language_name(self) -> str:
+        return "gleam"
+
+    def get_file_extensions(self) -> list[str]:
+        return self.config.file_extensions
+
+    def get_excluded_dirs(self) -> list[str]:
+        return self.config.excluded_dirs
+
+    def index_repository(
+        self,
+        repo_path: str | Path,
+        output_path: str | Path,
+        force: bool = False,  # noqa: ARG002 - interface compatibility
+        verbose: bool = False,
+        config_path: str | Path | None = None,  # noqa: ARG002 - interface compatibility
+    ) -> dict:
+        """Index a Gleam repository."""
+        repo_path = Path(repo_path)
+        output_path = Path(output_path)
+        modules, source_count, functions_count, errors = self._collect_modules(repo_path, verbose)
+
+        index_data = {
+            "modules": modules,
+            "metadata": {
+                "language": "gleam",
+                "files_indexed": source_count,
+                "modules_count": len(modules),
+                "functions_count": functions_count,
+            },
+        }
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        save_index(index_data, output_path)
+
+        if verbose:
+            print(f"Indexed {len(modules)} Gleam modules ({functions_count} functions)")
+
+        return {
+            "success": len(errors) == 0,
+            "modules_count": len(modules),
+            "functions_count": functions_count,
+            "files_indexed": source_count,
+            "errors": errors,
+        }
+
+    def merge_repository(
+        self,
+        repo_path: str | Path,
+        output_path: str | Path,
+        verbose: bool = False,
+    ) -> dict:
+        """Merge native Gleam modules into an existing multi-language index."""
+        repo_path = Path(repo_path)
+        output_path = Path(output_path)
+        modules, source_count, functions_count, errors = self._collect_modules(repo_path, verbose)
+
+        index_data = load_index(output_path) or {"modules": {}, "metadata": {}}
+        index_modules = index_data.setdefault("modules", {})
+        stale_modules = [
+            name
+            for name, module in index_modules.items()
+            if module.get("language") == "gleam" and name not in modules
+        ]
+        for name in stale_modules:
+            index_modules.pop(name, None)
+
+        index_modules.update(modules)
+        metadata = index_data.setdefault("metadata", {})
+        embedded = metadata.setdefault("embedded_languages", {})
+        embedded["gleam"] = {
+            "files_indexed": source_count,
+            "modules_count": len(modules),
+            "functions_count": functions_count,
+        }
+        save_index(index_data, output_path)
+
+        if verbose:
+            print(f"Indexed {len(modules)} embedded Gleam modules ({functions_count} functions)")
+
+        return {
+            "success": len(errors) == 0,
+            "modules_count": len(modules),
+            "functions_count": functions_count,
+            "files_indexed": source_count,
+            "errors": errors,
+        }
+
+    def _collect_modules(
+        self, repo_path: Path, verbose: bool
+    ) -> tuple[dict[str, dict], int, int, list[str]]:
+        extract_keywords, self.keyword_extractor = get_keyword_extractor_from_config(
+            repo_path, verbose=verbose
+        )
+
+        source_files = self._find_source_files(repo_path)
+        modules = {}
+        errors = []
+        functions_count = 0
+
+        for file_path in source_files:
+            try:
+                result = self.parser.parse_file(str(file_path), repo_path=repo_path)
+                if not result:
+                    continue
+
+                for module_data in result:
+                    module_name = module_data["module"]
+                    rel_path = str(file_path.relative_to(repo_path))
+                    functions = module_data.get("functions", [])
+                    keywords = {}
+                    if extract_keywords and self.keyword_extractor:
+                        keywords = self._extract_keywords(
+                            module_name,
+                            module_data.get("doc"),
+                            functions,
+                        )
+
+                    modules[module_name] = {
+                        "file": rel_path,
+                        "line": module_data.get("line", 1),
+                        "moduledoc": module_data.get("doc"),
+                        "functions": functions,
+                        "keywords": keywords,
+                        "language": "gleam",
+                    }
+                    functions_count += len(functions)
+            except Exception as exc:
+                errors.append(f"{file_path}: {exc}")
+
+        return modules, len(source_files), functions_count, errors
+
+    def _extract_keywords(
+        self,
+        module_name: str,
+        module_doc: str | None,
+        functions: list[dict],
+    ) -> dict[str, float]:
+        keywords: dict[str, float] = {}
+
+        for part in module_name.lower().replace("/", "_").split("_"):
+            if len(part) > 2:
+                keywords[part] = keywords.get(part, 0) + 1.5
+
+        if module_doc and self.keyword_extractor:
+            for keyword in self.keyword_extractor.extract_keywords_simple(module_doc):
+                keywords[keyword] = keywords.get(keyword, 0) + 1.0
+
+        for function in functions:
+            for part in function.get("name", "").lower().split("_"):
+                if len(part) > 2:
+                    keywords[part] = keywords.get(part, 0) + 1.0
+
+            function_doc = function.get("doc")
+            if function_doc and self.keyword_extractor:
+                for keyword in self.keyword_extractor.extract_keywords_simple(function_doc):
+                    keywords[keyword] = keywords.get(keyword, 0) + 0.5
+
+        return keywords

--- a/cicada/languages/gleam/parser.py
+++ b/cicada/languages/gleam/parser.py
@@ -1,0 +1,195 @@
+"""Gleam parser using tree-sitter."""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from tree_sitter_language_pack import get_language, get_parser
+
+from cicada.parsing.base_parser import BaseParser
+from cicada.parsing.language_config import LanguageConfig
+
+
+class GleamParser(BaseParser):
+    """Parse Gleam source files into Cicada's module/function index shape."""
+
+    def __init__(self):
+        self.parser = get_parser("gleam")
+        self.config = LanguageConfig.default_gleam()
+
+    def get_language_name(self) -> str:
+        return "gleam"
+
+    def get_tree_sitter_language(self) -> Any:
+        return get_language("gleam")
+
+    def get_file_extensions(self) -> list[str]:
+        return self.config.file_extensions
+
+    def parse_file(
+        self, file_path: str | Path, repo_path: str | Path | None = None
+    ) -> list[dict] | None:
+        path = Path(file_path)
+        source = path.read_bytes()
+        tree = self.parser.parse(source)
+        root = self._value(tree, "root_node")
+
+        module_name = self._module_name(path, Path(repo_path) if repo_path else None)
+        module_data: dict[str, Any] = {
+            "module": module_name,
+            "file": self._file_path(path, Path(repo_path) if repo_path else None),
+            "line": 1,
+            "functions": self._extract_functions(root, source),
+        }
+
+        module_doc = self._extract_module_doc(root, source)
+        if module_doc:
+            module_data["doc"] = module_doc
+
+        return [module_data]
+
+    def _module_name(self, file_path: Path, repo_path: Path | None) -> str:
+        if repo_path:
+            try:
+                relative = file_path.relative_to(repo_path)
+                parts = relative.with_suffix("").parts
+                if parts and parts[0] in {"src", "test"}:
+                    parts = parts[1:]
+                return "/".join(parts)
+            except ValueError:
+                pass
+
+        return file_path.with_suffix("").name
+
+    def _file_path(self, file_path: Path, repo_path: Path | None) -> str:
+        if repo_path:
+            try:
+                return file_path.relative_to(repo_path).as_posix()
+            except ValueError:
+                pass
+
+        return str(file_path)
+
+    def _extract_functions(self, root, source: bytes) -> list[dict[str, Any]]:
+        functions: list[dict[str, Any]] = []
+        pending_doc: str | None = None
+
+        for child in self._children(root):
+            node_type = self._node_type(child)
+            if node_type == "statement_comment":
+                pending_doc = self._append_doc(pending_doc, self._comment_content(child, source))
+                continue
+
+            if node_type == "function":
+                function = self._extract_function(child, source)
+                if function:
+                    if pending_doc:
+                        function["doc"] = pending_doc
+                    functions.append(function)
+                pending_doc = None
+                continue
+
+            if node_type not in {"module_comment"}:
+                pending_doc = None
+
+        return functions
+
+    def _extract_function(self, node, source: bytes) -> dict[str, Any] | None:
+        name: str | None = None
+        args: list[str] = []
+        is_public = False
+
+        for child in self._children(node):
+            node_type = self._node_type(child)
+            if node_type == "visibility_modifier" and self._text(child, source) == "pub":
+                is_public = True
+            elif node_type == "identifier" and name is None:
+                name = self._text(child, source)
+            elif node_type == "function_parameters":
+                args = self._extract_parameters(child, source)
+
+        if not name:
+            return None
+
+        return {
+            "name": name,
+            "arity": len(args),
+            "line": self._start_line(node),
+            "type": "def" if is_public else "defp",
+            "args": args,
+        }
+
+    def _extract_parameters(self, node, source: bytes) -> list[str]:
+        args = []
+        for child in self._children(node):
+            if self._node_type(child) != "function_parameter":
+                continue
+            identifier = self._first_child_of_type(child, "identifier")
+            args.append(self._text(identifier, source) if identifier else self._text(child, source))
+        return args
+
+    def _extract_module_doc(self, root, source: bytes) -> str | None:
+        doc_lines = []
+        for child in self._children(root):
+            if self._node_type(child) != "module_comment":
+                break
+            doc_lines.append(self._comment_content(child, source))
+        return self._join_doc(doc_lines)
+
+    def _comment_content(self, node, source: bytes) -> str:
+        content_parts = []
+        for child in self._children(node):
+            if self._node_type(child) == "doc_comment_content":
+                content_parts.append(self._text(child, source).strip())
+        return "\n".join(part for part in content_parts if part)
+
+    def _append_doc(self, current: str | None, line: str) -> str | None:
+        if not line:
+            return current
+        if not current:
+            return line
+        return f"{current}\n{line}"
+
+    def _join_doc(self, lines: list[str]) -> str | None:
+        doc = "\n".join(line for line in lines if line).strip()
+        return doc or None
+
+    def _first_child_of_type(self, node, wanted_type: str):
+        for child in self._children(node):
+            if self._node_type(child) == wanted_type:
+                return child
+        return None
+
+    def _children(self, node) -> list[Any]:
+        children = getattr(node, "children", None)
+        if children is not None:
+            return list(cast(Sequence[Any], children))
+
+        child_count = int(self._value(node, "child_count"))
+        return [node.child(i) for i in range(child_count)]
+
+    def _node_type(self, node) -> str:
+        node_type = getattr(node, "type", None)
+        if isinstance(node_type, str):
+            return node_type
+        return str(self._value(node, "kind"))
+
+    def _text(self, node, source: bytes) -> str:
+        start = int(self._value(node, "start_byte"))
+        end = int(self._value(node, "end_byte"))
+        return source[start:end].decode("utf-8")
+
+    def _start_line(self, node) -> int:
+        point = self._value(node, "start_point", fallback_name="start_position")
+        if hasattr(point, "row"):
+            return int(point.row) + 1
+        return int(cast(Sequence[Any], point)[0]) + 1
+
+    def _value(self, obj, name: str, fallback_name: str | None = None) -> Any:
+        if hasattr(obj, name):
+            value = getattr(obj, name)
+        elif fallback_name and hasattr(obj, fallback_name):
+            value = getattr(obj, fallback_name)
+        else:
+            raise AttributeError(name)
+        return value() if callable(value) else value

--- a/cicada/parsing/language_config.py
+++ b/cicada/parsing/language_config.py
@@ -168,6 +168,17 @@ class LanguageConfig:
         )
 
     @staticmethod
+    def default_gleam() -> "LanguageConfig":
+        """Create default Gleam configuration."""
+        return LanguageConfig(
+            language="gleam",
+            file_extensions=[".gleam"],
+            excluded_dirs=["_build", "build", "deps", ".git", "node_modules"],
+            tree_sitter_grammar="tree-sitter-gleam",
+            comment_syntax={"line": "//"},
+        )
+
+    @staticmethod
     def default_go() -> "LanguageConfig":
         """Create default Go configuration."""
         return LanguageConfig(

--- a/cicada/setup.py
+++ b/cicada/setup.py
@@ -71,6 +71,14 @@ def detect_project_language(repo_path: Path) -> str:
     if src_dir.exists() and any(src_dir.glob("*.erl")):
         return "erlang"
 
+    # Check for Gleam marker
+    if (repo_path / "gleam.toml").exists():
+        return "gleam"
+
+    # Fallback: Check for .gleam files in src/ directory (common Gleam convention)
+    if src_dir.exists() and any(src_dir.rglob("*.gleam")):
+        return "gleam"
+
     # Check for TypeScript/JavaScript markers
     ts_markers = ["tsconfig.json", "package.json"]
     for marker in ts_markers:
@@ -125,10 +133,35 @@ def detect_project_language(repo_path: Path) -> str:
     raise ValueError(
         f"Could not detect project language in {repo_path}\n"
         "Expected one of: Python (pyproject.toml), Elixir (mix.exs), Rust (Cargo.toml), "
-        "Erlang (rebar.config), TypeScript/JavaScript (package.json), Go (go.mod), "
-        "Java (build.gradle/pom.xml), Scala (build.sbt), C/C++ (CMakeLists.txt/Makefile), "
-        "Ruby (Gemfile), C# (*.csproj), VB (*.vbproj), Dart (pubspec.yaml)"
+        "Erlang (rebar.config), Gleam (gleam.toml), TypeScript/JavaScript (package.json), "
+        "Go (go.mod), Java (build.gradle/pom.xml), Scala (build.sbt), "
+        "C/C++ (CMakeLists.txt/Makefile), Ruby (Gemfile), C# (*.csproj), "
+        "VB (*.vbproj), Dart (pubspec.yaml)"
     )
+
+
+def _repo_contains_gleam(repo_path: Path) -> bool:
+    src_dir = repo_path / "src"
+    return (repo_path / "gleam.toml").exists() or (
+        src_dir.exists() and any(src_dir.rglob("*.gleam"))
+    )
+
+
+def _merge_embedded_gleam_index(
+    repo_path: Path,
+    index_path: Path,
+    primary_language: str,
+    verbose: bool,
+) -> list[str]:
+    if primary_language == "gleam" or not _repo_contains_gleam(repo_path):
+        return []
+
+    from cicada.languages.gleam.indexer import GleamIndexer
+
+    result = GleamIndexer().merge_repository(repo_path, index_path, verbose=verbose)
+    if not result["success"]:
+        raise RuntimeError("; ".join(result["errors"]))
+    return [".gleam"]
 
 
 def _setup_gitattributes(repo_path: Path) -> None:
@@ -396,7 +429,7 @@ def index_repository(
         # Use standard indexer interface
         indexer = LanguageRegistry.get_indexer(language)
         # Check if indexer supports incremental_index_repository (new unified API)
-        if hasattr(indexer, "incremental_index_repository"):
+        if getattr(indexer, "supports_incremental", False):
             indexer.incremental_index_repository(
                 repo_path=str(repo_path),
                 output_path=str(index_path),
@@ -415,11 +448,18 @@ def index_repository(
                 verbose=verbose,
                 config_path=str(config_path),
             )
+        extra_excluded_extensions = _merge_embedded_gleam_index(
+            repo_path,
+            index_path,
+            language,
+            verbose=verbose,
+        )
         run_generic_indexing_for_language_indexer(
             indexer,
             repo_path,
             index_path,
             verbose=verbose,
+            extra_excluded_extensions=extra_excluded_extensions,
         )
         # Don't print duplicate message - indexer already reports completion
     except Exception as e:

--- a/tests/gleam/test_embedded_gleam.py
+++ b/tests/gleam/test_embedded_gleam.py
@@ -1,0 +1,60 @@
+import json
+
+from cicada.setup import _merge_embedded_gleam_index
+
+
+def test_merge_embedded_gleam_skips_primary_gleam(tmp_path):
+    output_path = tmp_path / "index.json"
+
+    result = _merge_embedded_gleam_index(tmp_path, output_path, "gleam", verbose=False)
+
+    assert result == []
+    assert not output_path.exists()
+
+
+def test_merge_embedded_gleam_for_non_gleam_primary(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tools.gleam").write_text("pub fn run() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    output_path.write_text(json.dumps({"modules": {}, "metadata": {"language": "elixir"}}))
+
+    result = _merge_embedded_gleam_index(tmp_path, output_path, "elixir", verbose=False)
+
+    assert result == [".gleam"]
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["modules"]["tools"]["functions"][0]["name"] == "run"
+
+
+def test_merge_embedded_gleam_skips_non_gleam_primary_without_gleam_files(tmp_path):
+    output_path = tmp_path / "index.json"
+    original = {"modules": {}, "metadata": {"language": "elixir"}}
+    output_path.write_text(json.dumps(original), encoding="utf-8")
+
+    result = _merge_embedded_gleam_index(tmp_path, output_path, "elixir", verbose=False)
+
+    assert result == []
+    assert json.loads(output_path.read_text(encoding="utf-8")) == original
+
+
+def test_merge_embedded_gleam_raises_on_merge_failure(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tools.gleam").write_text("pub fn run() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    output_path.write_text(json.dumps({"modules": {}, "metadata": {"language": "elixir"}}))
+
+    def merge_repository(*_args, **_kwargs):
+        return {"success": False, "errors": ["first failure", "second failure"]}
+
+    monkeypatch.setattr(
+        "cicada.languages.gleam.indexer.GleamIndexer.merge_repository",
+        merge_repository,
+    )
+
+    try:
+        _merge_embedded_gleam_index(tmp_path, output_path, "elixir", verbose=False)
+    except RuntimeError as exc:
+        assert str(exc) == "first failure; second failure"
+    else:
+        raise AssertionError("expected RuntimeError")

--- a/tests/gleam/test_gleam_formatter.py
+++ b/tests/gleam/test_gleam_formatter.py
@@ -1,0 +1,17 @@
+from cicada.languages.gleam.formatter import GleamFormatter
+
+
+def test_format_function_identifier():
+    formatter = GleamFormatter()
+
+    assert (
+        formatter.format_function_identifier("wardwright/lustre_model_access", "update", 2)
+        == "wardwright/lustre_model_access.update/2"
+    )
+
+
+def test_format_function_name_with_args():
+    formatter = GleamFormatter()
+
+    assert formatter.format_function_name("update", 2, ["model", "msg"]) == "update(model, msg)"
+    assert formatter.format_function_name("init", 0) == "init/0"

--- a/tests/gleam/test_gleam_indexer.py
+++ b/tests/gleam/test_gleam_indexer.py
@@ -1,0 +1,258 @@
+import json
+from pathlib import Path
+
+import cicada.languages.gleam.indexer as gleam_indexer_module
+from cicada.languages.gleam.indexer import GleamIndexer
+
+
+def test_index_repository(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    gleam_file = src / "validator.gleam"
+    gleam_file.write_text(
+        """//// Validation helpers.
+
+/// Validate a payload.
+pub fn validate(payload: String) -> Bool {
+  payload != ""
+}
+
+fn normalize(payload: String) -> String {
+  payload
+}
+""",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "index.json"
+
+    result = GleamIndexer().index_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    assert result["modules_count"] == 1
+    assert result["functions_count"] == 2
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    module = data["modules"]["validator"]
+    assert module["file"] == "src/validator.gleam"
+    assert module["moduledoc"] == "Validation helpers."
+
+    functions = {function["name"]: function for function in module["functions"]}
+    assert functions["validate"]["type"] == "def"
+    assert functions["normalize"]["type"] == "defp"
+
+
+def test_indexer_reports_language_metadata():
+    indexer = GleamIndexer()
+
+    assert indexer.get_language_name() == "gleam"
+    assert indexer.get_file_extensions() == [".gleam"]
+    assert "_build" in indexer.get_excluded_dirs()
+
+
+def test_index_repository_records_parse_errors_and_keeps_valid_modules(tmp_path: Path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    valid_file = src / "valid.gleam"
+    valid_file.write_text("pub fn ok() -> Bool {\n  True\n}\n", encoding="utf-8")
+    invalid_file = src / "invalid.gleam"
+    invalid_file.write_text("pub fn broken() {\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    indexer = GleamIndexer()
+    original_parse_file = indexer.parser.parse_file
+
+    def parse_file(path, repo_path=None):
+        if Path(path) == invalid_file:
+            raise ValueError("parse error")
+        return original_parse_file(path, repo_path=repo_path)
+
+    monkeypatch.setattr(indexer.parser, "parse_file", parse_file)
+
+    result = indexer.index_repository(tmp_path, output_path)
+
+    assert result["success"] is False
+    assert any(str(invalid_file) in error and "parse error" in error for error in result["errors"])
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["modules"]["valid"]["functions"][0]["name"] == "ok"
+
+
+def test_index_repository_skips_files_without_parse_result(tmp_path: Path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "empty.gleam").write_text("pub fn ignored() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    indexer = GleamIndexer()
+    monkeypatch.setattr(indexer.parser, "parse_file", lambda *_args, **_kwargs: None)
+
+    result = indexer.index_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    assert result["modules_count"] == 0
+    assert result["functions_count"] == 0
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["modules"] == {}
+
+
+def test_indexer_verbose_output(tmp_path, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.gleam").write_text("pub fn main() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+
+    GleamIndexer().index_repository(tmp_path, output_path, verbose=True)
+
+    captured = capsys.readouterr()
+    assert "Indexed 1 Gleam modules" in captured.out
+
+
+def test_merge_repository_verbose_output(tmp_path, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "embedded.gleam").write_text("pub fn main() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    output_path.write_text(json.dumps({"modules": {}, "metadata": {"language": "elixir"}}))
+
+    GleamIndexer().merge_repository(tmp_path, output_path, verbose=True)
+
+    captured = capsys.readouterr()
+    assert "Indexed 1 embedded Gleam modules" in captured.out
+
+
+def test_indexer_keyword_extraction(tmp_path: Path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "auth_handler.gleam").write_text(
+        """//// Authentication helpers.
+
+/// Validate an authentication token.
+pub fn validate_token(token: String) -> Bool {
+  token != ""
+}
+""",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "index.json"
+
+    class FakeKeywordExtractor:
+        def extract_keywords_simple(self, text):
+            return [f"kw:{text.split()[0].lower()}"]
+
+    monkeypatch.setattr(
+        gleam_indexer_module,
+        "get_keyword_extractor_from_config",
+        lambda *_args, **_kwargs: (True, FakeKeywordExtractor()),
+    )
+
+    result = GleamIndexer().index_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    keywords = data["modules"]["auth_handler"]["keywords"]
+    assert keywords["auth"] == 1.5
+    assert keywords["handler"] == 1.5
+    assert keywords["validate"] == 1.0
+    assert keywords["token"] == 1.0
+    assert keywords["kw:authentication"] == 1.0
+    assert keywords["kw:validate"] == 0.5
+
+
+def test_indexer_leaves_keywords_empty_when_extraction_disabled(tmp_path: Path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "ui.gleam").write_text(
+        """pub fn ok() {
+  Nil
+}
+""",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "index.json"
+    monkeypatch.setattr(
+        gleam_indexer_module,
+        "get_keyword_extractor_from_config",
+        lambda *_args, **_kwargs: (False, None),
+    )
+
+    result = GleamIndexer().index_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["modules"]["ui"]["keywords"] == {}
+
+
+def test_merge_repository_adds_gleam_modules_to_existing_index(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "policy.gleam").write_text(
+        'pub fn check(value: String) -> Bool {\n  value != ""\n}\n',
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "index.json"
+    output_path.write_text(
+        json.dumps(
+            {
+                "modules": {
+                    "Existing.Elixir": {
+                        "file": "lib/existing.ex",
+                        "line": 1,
+                        "functions": [],
+                    }
+                },
+                "metadata": {"language": "elixir"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = GleamIndexer().merge_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "Existing.Elixir" in data["modules"]
+    assert data["modules"]["policy"]["language"] == "gleam"
+    assert data["modules"]["policy"]["functions"][0]["name"] == "check"
+    assert data["metadata"]["embedded_languages"]["gleam"]["functions_count"] == 1
+
+
+def test_merge_repository_removes_stale_gleam_modules(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "current.gleam").write_text("pub fn run() { Nil }\n", encoding="utf-8")
+    output_path = tmp_path / "index.json"
+    output_path.write_text(
+        json.dumps(
+            {
+                "modules": {
+                    "current": {
+                        "file": "src/current.gleam",
+                        "line": 1,
+                        "functions": [],
+                        "language": "gleam",
+                    },
+                    "deleted": {
+                        "file": "src/deleted.gleam",
+                        "line": 1,
+                        "functions": [],
+                        "language": "gleam",
+                    },
+                    "README.md": {
+                        "file": "README.md",
+                        "line": 1,
+                        "functions": [],
+                        "module_type": "generic_file",
+                    },
+                },
+                "metadata": {"language": "elixir"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = GleamIndexer().merge_repository(tmp_path, output_path)
+
+    assert result["success"] is True
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "current" in data["modules"]
+    assert "deleted" not in data["modules"]
+    assert "README.md" in data["modules"]

--- a/tests/gleam/test_gleam_parser.py
+++ b/tests/gleam/test_gleam_parser.py
@@ -1,0 +1,214 @@
+from pathlib import Path
+
+from cicada.languages.gleam.parser import GleamParser
+
+
+class LegacyPoint:
+    def __init__(self, row: int):
+        self.row = row
+
+
+class LegacyNode:
+    """Small stand-in for older Tree-sitter nodes with callable attributes."""
+
+    def __init__(
+        self,
+        kind: str,
+        *,
+        text_range: tuple[int, int] = (0, 0),
+        children: list["LegacyNode"] | None = None,
+        row: int = 0,
+        use_row_attr: bool = False,
+    ):
+        self.kind = kind
+        self.start_byte, self.end_byte = text_range
+        self._children = children or []
+        self.start_position = LegacyPoint(row) if use_row_attr else (row, 0)
+
+    def child_count(self):
+        return len(self._children)
+
+    def child(self, index: int):
+        return self._children[index]
+
+
+def write_sample(tmp_path: Path) -> Path:
+    source = tmp_path / "src" / "wardwright" / "model.gleam"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        """//// Model management helpers.
+//// Used by the Wardwright admin UI.
+
+pub type Model {
+  Model(name: String)
+}
+
+/// Build a model from a name.
+pub fn make_model(name: String) -> Model {
+  Model(name: name)
+}
+
+/// Prefix a model name.
+/// Keeps display naming consistent.
+fn display_name(model: Model, prefix: String) -> String {
+  prefix <> model.name
+}
+""",
+        encoding="utf-8",
+    )
+    return source
+
+
+def test_parse_module_name_and_docs(tmp_path):
+    parser = GleamParser()
+    source = write_sample(tmp_path)
+
+    result = parser.parse_file(source, repo_path=tmp_path)
+
+    assert result is not None
+    assert result[0]["module"] == "wardwright/model"
+    assert result[0]["file"] == "src/wardwright/model.gleam"
+    assert result[0]["doc"] == "Model management helpers.\nUsed by the Wardwright admin UI."
+
+
+def test_parse_function_visibility_arity_args_and_docs(tmp_path):
+    parser = GleamParser()
+    source = write_sample(tmp_path)
+
+    module = parser.parse_file(source, repo_path=tmp_path)[0]
+    functions = {function["name"]: function for function in module["functions"]}
+
+    assert functions["make_model"]["type"] == "def"
+    assert functions["make_model"]["arity"] == 1
+    assert functions["make_model"]["args"] == ["name"]
+    assert functions["make_model"]["doc"] == "Build a model from a name."
+
+    assert functions["display_name"]["type"] == "defp"
+    assert functions["display_name"]["arity"] == 2
+    assert functions["display_name"]["args"] == ["model", "prefix"]
+    assert functions["display_name"]["doc"] == (
+        "Prefix a model name.\nKeeps display naming consistent."
+    )
+
+
+def test_parse_clears_orphan_doc_before_next_function(tmp_path):
+    source = tmp_path / "src" / "orphan.gleam"
+    source.parent.mkdir()
+    source.write_text(
+        """/// This doc belongs to no function.
+pub const default_name = "default"
+
+// Plain comments should not become function docs.
+pub fn next() {
+  Nil
+}
+""",
+        encoding="utf-8",
+    )
+
+    module = GleamParser().parse_file(source, repo_path=tmp_path)[0]
+    functions = {function["name"]: function for function in module["functions"]}
+
+    assert "doc" not in functions["next"]
+
+
+def test_parse_root_level_module_name(tmp_path):
+    source = tmp_path / "tools.gleam"
+    source.write_text("pub fn run() { Nil }\n", encoding="utf-8")
+
+    module = GleamParser().parse_file(source, repo_path=tmp_path)[0]
+
+    assert module["module"] == "tools"
+    assert module["file"] == "tools.gleam"
+
+
+def test_parse_without_repo_path_uses_local_file_identity(tmp_path):
+    source = tmp_path / "standalone.gleam"
+    source.write_text("pub fn run() { Nil }\n", encoding="utf-8")
+
+    module = GleamParser().parse_file(source)[0]
+
+    assert module["module"] == "standalone"
+    assert module["file"] == str(source)
+
+
+def test_empty_doc_comment_does_not_attach_blank_function_doc(tmp_path):
+    source = tmp_path / "src" / "blank_doc.gleam"
+    source.parent.mkdir()
+    source.write_text(
+        """///
+pub fn next() {
+  Nil
+}
+""",
+        encoding="utf-8",
+    )
+
+    module = GleamParser().parse_file(source, repo_path=tmp_path)[0]
+    functions = {function["name"]: function for function in module["functions"]}
+
+    assert "doc" not in functions["next"]
+
+
+def test_parser_reports_language_metadata():
+    parser = GleamParser()
+
+    assert parser.get_language_name() == "gleam"
+    assert parser.get_file_extensions() == [".gleam"]
+    assert parser.get_tree_sitter_language() is not None
+
+
+def test_parse_file_outside_repo_uses_file_name_and_absolute_path(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = tmp_path / "external.gleam"
+    source.write_text("pub fn run() { Nil }\n", encoding="utf-8")
+
+    module = GleamParser().parse_file(source, repo_path=repo)[0]
+
+    assert module["module"] == "external"
+    assert module["file"] == str(source)
+
+
+def test_legacy_tree_sitter_node_shape_still_extracts_function_data():
+    source = b"pub fn run(value) { value }"
+    parameter = LegacyNode("function_parameter", text_range=(11, 16))
+    parameters = LegacyNode("function_parameters", children=[parameter])
+    node = LegacyNode(
+        "function",
+        children=[
+            LegacyNode("visibility_modifier", text_range=(0, 3)),
+            LegacyNode("identifier", text_range=(7, 10)),
+            parameters,
+        ],
+        row=3,
+    )
+
+    function = GleamParser()._extract_function(node, source)
+
+    assert function == {
+        "name": "run",
+        "arity": 1,
+        "line": 4,
+        "type": "def",
+        "args": ["value"],
+    }
+
+
+def test_legacy_tree_sitter_row_attribute_and_missing_name_paths():
+    parser = GleamParser()
+    nameless_node = LegacyNode("function", children=[LegacyNode("function_parameters")])
+
+    assert parser._extract_function(nameless_node, b"fn () { Nil }") is None
+    assert parser._start_line(LegacyNode("function", row=8, use_row_attr=True)) == 9
+
+
+def test_tree_sitter_value_helper_reports_missing_attribute():
+    parser = GleamParser()
+
+    try:
+        parser._value(object(), "missing")
+    except AttributeError as exc:
+        assert str(exc) == "missing"
+    else:
+        raise AssertionError("expected AttributeError for missing tree-sitter attribute")

--- a/tests/gleam/test_gleam_setup.py
+++ b/tests/gleam/test_gleam_setup.py
@@ -1,0 +1,15 @@
+from cicada.setup import detect_project_language
+
+
+def test_detect_gleam_toml(tmp_path):
+    (tmp_path / "gleam.toml").write_text('[project]\nname = "sample"\n', encoding="utf-8")
+
+    assert detect_project_language(tmp_path) == "gleam"
+
+
+def test_detect_gleam_source_fallback(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.gleam").write_text("pub fn main() { Nil }\n", encoding="utf-8")
+
+    assert detect_project_language(tmp_path) == "gleam"

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -2,7 +2,7 @@
 End-to-end integration tests for Cicada.
 """
 
-import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -12,12 +12,28 @@ from cicada.indexer import ElixirIndexer
 from cicada.mcp.server import CicadaServer
 
 
+def write_minimal_elixir_repo(repo_path: Path) -> None:
+    """Create a tiny Elixir repo for tests that only need a valid index."""
+    (repo_path / "sample.ex").write_text(
+        """
+defmodule Test do
+  def hello do
+    "world"
+  end
+end
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture
 def index_path(tmp_path):
     """Fixture to create test index."""
+    write_minimal_elixir_repo(tmp_path)
     indexer = ElixirIndexer()
     output_path = tmp_path / "test_e2e_index.json"
-    indexer.index_repository("tests/fixtures", str(output_path))
+    indexer.index_repository(str(tmp_path), str(output_path))
     yield str(output_path)
 
 
@@ -68,7 +84,7 @@ def test_indexer(tmp_path):
     print(f"  ✓ Total functions: {total_funcs}")
 
 
-def test_mcp_server_initialization(index_path):
+def test_mcp_server_initialization(index_path, tmp_path):
     """Test that the MCP server can initialize and load the index."""
     print("\nTesting MCP server initialization...")
 
@@ -78,13 +94,13 @@ def test_mcp_server_initialization(index_path):
         "storage": {"index_path": index_path},
     }
 
-    test_config_path = "test_config.yaml"
+    test_config_path = tmp_path / "test_config.yaml"
     with open(test_config_path, "w") as f:
         yaml.dump(test_config, f)
 
     try:
         # Initialize server
-        server = CicadaServer(test_config_path)
+        server = CicadaServer(str(test_config_path))
 
         # Verify index was loaded
         assert server.index_manager.index is not None, "Index not loaded"
@@ -95,8 +111,8 @@ def test_mcp_server_initialization(index_path):
 
     finally:
         # Cleanup
-        if os.path.exists(test_config_path):
-            os.remove(test_config_path)
+        if test_config_path.exists():
+            test_config_path.unlink()
 
 
 def test_module_not_found(tmp_path):
@@ -115,12 +131,12 @@ def test_module_not_found(tmp_path):
 
     import yaml
 
-    test_config_path = "test_config.yaml"
+    test_config_path = tmp_path / "test_config.yaml"
     with open(test_config_path, "w") as f:
         yaml.dump(test_config, f)
 
     try:
-        server = CicadaServer(test_config_path)
+        server = CicadaServer(str(test_config_path))
 
         # Search for non-existent module
         import asyncio
@@ -136,17 +152,14 @@ def test_module_not_found(tmp_path):
         print("  ✓ Module not found error handled correctly")
 
     finally:
-        if os.path.exists(test_config_path):
-            os.remove(test_config_path)
+        if test_config_path.exists():
+            test_config_path.unlink()
 
 
 if __name__ == "__main__":
     print("Running end-to-end tests...\n")
 
     try:
-        from pathlib import Path
-        import tempfile
-
         tmp_dir = Path(tempfile.mkdtemp())
 
         # Test indexer
@@ -154,7 +167,7 @@ if __name__ == "__main__":
         index_path = str(tmp_dir / "test_e2e_index.json")
 
         # Test MCP server
-        test_mcp_server_initialization(index_path)
+        test_mcp_server_initialization(index_path, tmp_dir)
 
         # Test error handling
         test_module_not_found(tmp_dir)

--- a/tests/setup/test_setup.py
+++ b/tests/setup/test_setup.py
@@ -340,6 +340,64 @@ class TestIndexRepository:
                     with pytest.raises(Exception, match="Indexing failed"):
                         index_repository(mock_repo, language="elixir")
 
+    def test_calls_non_incremental_indexer(self, mock_repo):
+        """Should call index_repository for indexers without incremental support."""
+        with (
+            patch("cicada.setup.LanguageRegistry.get_indexer") as mock_get_indexer,
+            patch("cicada.setup.get_index_path") as mock_get_index,
+            patch("cicada.setup.get_config_path") as mock_get_config,
+        ):
+            mock_indexer = MagicMock()
+            mock_indexer.supports_incremental = False
+            mock_indexer.index_repository = MagicMock()
+            mock_indexer.get_file_extensions.return_value = [".gleam"]
+            mock_get_indexer.return_value = mock_indexer
+
+            index_path = mock_repo / "index.json"
+            mock_get_index.return_value = index_path
+
+            config_path = mock_repo / "config.yaml"
+            mock_get_config.return_value = config_path
+
+            index_repository(mock_repo, language="gleam")
+
+            mock_indexer.index_repository.assert_called_once_with(
+                repo_path=str(mock_repo),
+                output_path=str(index_path),
+                force=False,
+                verbose=True,
+                config_path=str(config_path),
+            )
+            mock_indexer.incremental_index_repository.assert_not_called()
+
+    def test_calls_legacy_indexer_without_incremental_flag(self, mock_repo):
+        """Should treat indexers without supports_incremental as non-incremental."""
+        with (
+            patch("cicada.setup.LanguageRegistry.get_indexer") as mock_get_indexer,
+            patch("cicada.setup.get_index_path") as mock_get_index,
+            patch("cicada.setup.get_config_path") as mock_get_config,
+        ):
+            mock_indexer = MagicMock()
+            del mock_indexer.supports_incremental
+            mock_indexer.index_repository = MagicMock()
+            mock_indexer.get_file_extensions.return_value = [".legacy"]
+            mock_get_indexer.return_value = mock_indexer
+
+            index_path = mock_repo / "index.json"
+            mock_get_index.return_value = index_path
+            config_path = mock_repo / "config.yaml"
+            mock_get_config.return_value = config_path
+
+            index_repository(mock_repo, language="legacy")
+
+            mock_indexer.index_repository.assert_called_once_with(
+                repo_path=str(mock_repo),
+                output_path=str(index_path),
+                force=False,
+                verbose=True,
+                config_path=str(config_path),
+            )
+
 
 # ============================================================================
 # Setup Function Tests


### PR DESCRIPTION
## Summary
- add native Gleam parser, indexer, and formatter support using tree-sitter-language-pack
- detect pure Gleam projects via gleam.toml or src/**/*.gleam
- merge embedded Gleam modules into mixed-language indexes so BEAM apps with Elixir plus Gleam get function-level Gleam navigation instead of generic text-only entries

## Validation
- /opt/homebrew/bin/uv run pytest tests/gleam tests/test_language_registry.py tests/setup/test_setup.py tests/test_commands.py -q
- /opt/homebrew/bin/uv run ruff check cicada/languages/gleam cicada/languages/__init__.py cicada/parsing/language_config.py cicada/setup.py cicada/commands.py tests/gleam
- /opt/homebrew/bin/uv run black --check cicada/languages/gleam cicada/languages/__init__.py cicada/parsing/language_config.py cicada/setup.py cicada/commands.py tests/gleam tests/setup/test_setup.py

## Manual check
- Indexed a mixed Elixir/Gleam app and confirmed 21 Gleam modules / 370 Gleam functions were indexed natively instead of as generic files.