### PR TITLE
Fix pyrefly type errors in search handler index properties

### DIFF
--- a/cicada/mcp/handlers/function_handlers.py
+++ b/cicada/mcp/handlers/function_handlers.py
@@ -47,7 +47,8 @@ class FunctionSearchHandler:
     def index(self) -> dict[str, Any]:
         """Return the current code index, read through the source on each access."""
         source = self._index_source
-        return source.index if hasattr(source, "index") else source
+        result = source.index if hasattr(source, "index") else source
+        return cast("dict[str, Any]", result)
 
     @index.setter
     def index(self, value: "IndexManager | dict[str, Any]") -> None:

--- a/cicada/mcp/handlers/module_handlers.py
+++ b/cicada/mcp/handlers/module_handlers.py
@@ -46,7 +46,8 @@ class ModuleSearchHandler:
     def index(self) -> dict[str, Any]:
         """Return the current code index, read through the source on each access."""
         source = self._index_source
-        return source.index if hasattr(source, "index") else source
+        result = source.index if hasattr(source, "index") else source
+        return cast("dict[str, Any]", result)
 
     @index.setter
     def index(self, value: "IndexManager | dict[str, Any]") -> None:


### PR DESCRIPTION
## Summary
- Main CI (`Lint & Type Check`) fails after #245/#246 because `index` properties return `IndexManager | dict[str, Any]` where `dict[str, Any]` is declared
- Cast the resolved value in `function_handlers` and `module_handlers` so pyrefly accepts the return type

## Test plan
- [x] Local pyrefly check → 0 errors
- [x] Pre-commit tests → 3816 passed
- [ ] Confirm GitHub Actions Lint & Type Check passes on this PR


Made with [Cursor](https://cursor.com)